### PR TITLE
fix: add exclude rule for long tests names [LUM-572]

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,3 +85,8 @@ run:
     - internal/hidden/versions/embed.go
     - internal/private/versions/embed.go
     - cmd/load-testing-target-generator/data.go
+issues:
+  exclude-rules:
+    - linters:
+        - lll
+      source: "^func Test_"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add linting exclude rule for long tests names only.

### More information

- [Jira ticket](https://snyksec.atlassian.net/browse/LUM-572)
