### PR TITLE
fix: [prodsec review] use dummy org id [LUM-572]

### DIFF
--- a/internal/workflows/sbom/http_sbom_client_test.go
+++ b/internal/workflows/sbom/http_sbom_client_test.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	version = "2022-03-31~experimental"
-	orgID   = "aaacbb21-19b4-44f4-8483-d03746156f6b"
+	orgID   = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	format  = sbomconstants.SbomValidFormats[0]
 )
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

As part of ProdSec review we need to use dummy org ids.

### More information

- [Jira ticket](https://snyksec.atlassian.net/browse/LUM-572)
