### PR TITLE
fix: fix exclude-app-vulns flag not respected [LUM-620]

### DIFF
--- a/internal/common/flags/flags.go
+++ b/internal/common/flags/flags.go
@@ -18,28 +18,16 @@ import (
 	"fmt"
 
 	"github.com/snyk/container-cli/internal/workflows/sbom/constants"
-	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
 var (
-	FlagDebug = NewBoolFlag(
-		configuration.DEBUG,
-		false,
-		"",
-	)
-	FlagAppVulns = NewBoolFlag(
-		"app-vulns",
-		false,
-		"enable app-vulns (deprecated, as this is the default value)",
-	)
 	FlagExcludeAppVulns = NewBoolFlag(
 		"exclude-app-vulns",
 		false,
 		"disable app-vulns",
 	)
-	FlagSbomFormat = NewShortHandStringFlag(
+	FlagSbomFormat = NewStringFlag(
 		"format",
-		"f",
 		"",
 		fmt.Sprintf("Specify the SBOM output format. %s", constants.SbomValidFormats),
 	)

--- a/internal/workflows/depgraph/depgraph.go
+++ b/internal/workflows/depgraph/depgraph.go
@@ -40,8 +40,6 @@ var Workflow = &DepGraphWorkflow{
 	BaseWorkflow: workflows.BaseWorkflow{
 		Name: "container depgraph",
 		Flags: []flags.Flag{
-			flags.FlagDebug,
-			flags.FlagAppVulns,
 			flags.FlagExcludeAppVulns,
 		},
 	},

--- a/internal/workflows/depgraph/depgraph_test.go
+++ b/internal/workflows/depgraph/depgraph_test.go
@@ -263,9 +263,20 @@ func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNi
 	require.Equal(t, depgraphTarget02, result[1].GetContentLocation())
 }
 
+func Test_InitWorkflow_GivenFlags_ShouldRegisterFlagsToWorkflowAndReturnThemInConfig(t *testing.T) {
+	config := configuration.New()
+	engine := workflow.NewWorkFlowEngine(config)
+
+	err := Workflow.InitWorkflow(engine)
+	require.Nil(t, err)
+
+	require.Len(t, Workflow.Flags, 1)
+
+	flagExcludeAppVulns := config.Get(flags.FlagExcludeAppVulns.Name)
+	require.NotNil(t, flagExcludeAppVulns)
+}
+
 func initMocks() {
-	mockConfig.EXPECT().GetBool(flags.FlagDebug.Name).Return(false)
-	mockConfig.EXPECT().GetBool(flags.FlagAppVulns.Name).Return(false)
 	mockConfig.EXPECT().GetBool(flags.FlagExcludeAppVulns.Name).Return(false)
 	mockConfig.EXPECT().GetString(constants.ContainerTargetArgName).Return(testContainerTargetArg)
 	mockConfig.EXPECT().Set(configuration.RAW_CMD_ARGS, gomock.AssignableToTypeOf([]string{}))
@@ -280,15 +291,3 @@ func buildData(identifier workflow.Identifier, payload interface{}, target strin
 
 	return d
 }
-
-// TODO: reference test Ramon wrote to test the initWorkflow func
-// func Test_InitWorkflow_InitDepGraphWorkflow(t *testing.T) {
-//	config := configuration.New()
-//	engine := workflow.NewWorkFlowEngine(config)
-//
-//	err := Workflow.InitWorkflow(engine)
-//	assert.Nil(t, err)
-//
-//	flagBool := config.Get("debug")
-//	assert.Equal(t, false, flagBool)
-//}

--- a/internal/workflows/sbom/sbom.go
+++ b/internal/workflows/sbom/sbom.go
@@ -45,6 +45,7 @@ func NewWorkflow(sbomClient SbomClient, errFactory *sbomerrors.SbomErrorFactory)
 			Name: "container sbom",
 			Flags: []flags.Flag{
 				flags.FlagSbomFormat,
+				flags.FlagExcludeAppVulns,
 			},
 		},
 		depGraph:   containerdepgraph.Workflow,

--- a/internal/workflows/sbom/sbom_test.go
+++ b/internal/workflows/sbom/sbom_test.go
@@ -213,6 +213,24 @@ func Test_Entrypoint_GivenNoError_ShouldReturnSbomAsWorkflowData(t *testing.T) {
 	require.Equal(t, result[0].GetPayload(), expectedSbomResult.Doc)
 }
 
+func Test_Init_GivenWorkflowFlags_ShouldRegisterFlagsToWorkflowAndReturnThemInConfigInsteadOfNil(t *testing.T) {
+	config := configuration.New()
+	engine := workflow.NewWorkFlowEngine(config)
+
+	sbomWorkflow := NewWorkflow(nil, nil)
+
+	err := sbomWorkflow.Init(engine)
+	require.Nil(t, err)
+
+	require.Len(t, sbomWorkflow.Flags, 2)
+
+	flagSbomFormat := config.Get(flags.FlagSbomFormat.Name)
+	require.NotNil(t, flagSbomFormat)
+
+	flagExcludeAppVulns := config.Get(flags.FlagExcludeAppVulns.Name)
+	require.NotNil(t, flagExcludeAppVulns)
+}
+
 func getInvalidDepGraph() workflow.Data {
 	// a boolean payload (e.g. true) is not valid
 	invalidDepGraph := workflow.NewData(workflow.NewTypeIdentifier(workflow.NewWorkflowIdentifier("container depgraph"),


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

fix `exclude-app-vulns` flag not being respected by `container sbom` command
also, remove `app-vulns` flag from the `container sbom` workflow.

### More information

- [Jira ticket](https://snyksec.atlassian.net/browse/LUM-620)
