### PR TITLE
fix: add error code number to depgraph errors [LUM-653]

### DIFF
--- a/internal/common/errors/constants.go
+++ b/internal/common/errors/constants.go
@@ -1,0 +1,19 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+const (
+	DepGraphWorkflowErrCode = "DGW"
+)

--- a/internal/common/errors/error_test.go
+++ b/internal/common/errors/error_test.go
@@ -1,0 +1,73 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/snyk/container-cli/internal/common/errors"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Error_GivenErrorWithUserMessageAndWithoutWorkflowError_ShouldReturnUserMessageOnly(t *testing.T) {
+	err := "test error"
+	userMessage := "test user message"
+	errorCode := 42
+	workflowErrorCode := ""
+
+	unit := errors.NewContainerExtensionError(fmt.Errorf(err), userMessage, errorCode, workflowErrorCode)
+	result := unit.Error()
+
+	require.Equal(t, userMessage, result)
+}
+
+func Test_Error_GivenErrorWithUserMessageAndWorkflowErrorCodeAndErrorCode_ShouldReturnUserMessageAndAppendWorkflowErrorCodeAndErrorCode(t *testing.T) {
+	err := "test error"
+	userMessage := "test user message"
+	errorCode := 42
+	workflowErrorCode := "A"
+
+	expectedErrorMessage := fmt.Sprintf("%s [ERR#%s%d]", userMessage, workflowErrorCode, errorCode)
+
+	unit := errors.NewContainerExtensionError(fmt.Errorf(err), userMessage, errorCode, workflowErrorCode)
+	result := unit.Error()
+
+	require.Equal(t, expectedErrorMessage, result)
+}
+
+func Test_Error_GivenNestedErrorWithUserMessageAndWorkflowErrorCodeAndErrorCode_ShouldReturnUserMessageOfTheLastErrorAndAppendWorkflowErrorCodeAndErrorCodeAndTheNestedErrorWorkflowErrorCodeAndErrorCode(t *testing.T) {
+	nestedErr := "test error 01"
+	nestedUserMessage := "test user message 01"
+	nestedWorkflowErrorCode := "B"
+	nestedErrorCode := 42
+
+	userMessage := "test user message 02"
+	workflowErrorCode := "A"
+	errorCode := 24
+
+	expectedErrorMessage := fmt.Sprintf(
+		"%s [ERR#%s%d+%s%d]", userMessage, workflowErrorCode, errorCode, nestedWorkflowErrorCode, nestedErrorCode,
+	)
+
+	nestedContainerExtensionError := errors.NewContainerExtensionError(
+		fmt.Errorf(nestedErr), nestedUserMessage, nestedErrorCode, nestedWorkflowErrorCode,
+	)
+	unit := errors.NewContainerExtensionError(nestedContainerExtensionError, userMessage, errorCode, workflowErrorCode)
+	result := unit.Error()
+
+	require.Equal(t, expectedErrorMessage, result)
+}

--- a/internal/workflows/depgraph/depgraph_test.go
+++ b/internal/workflows/depgraph/depgraph_test.go
@@ -157,7 +157,7 @@ func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsEmpty_Should
 
 	_, err := unit.entrypoint(mockInvocationContext, nil)
 
-	require.EqualError(t, err, expectedErrorMessage)
+	require.ErrorContains(t, err, expectedErrorMessage)
 }
 
 func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNil_ShouldReturnInternalError(t *testing.T) {
@@ -172,7 +172,7 @@ func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNil_ShouldRe
 
 	_, err := unit.entrypoint(mockInvocationContext, nil)
 
-	require.EqualError(t, err, expectedErrorMessage)
+	require.ErrorContains(t, err, expectedErrorMessage)
 }
 
 func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNilAndPayloadFailedToConvertToByteArray_ShouldReturnInternalError(t *testing.T) {
@@ -189,7 +189,7 @@ func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNi
 
 	_, err := unit.entrypoint(mockInvocationContext, nil)
 
-	require.EqualError(t, err, expectedErrorMessage)
+	require.ErrorContains(t, err, expectedErrorMessage)
 }
 
 func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNilAndPayloadConvertToByteArrayAndTheByteArrayIsEmpty_ShouldReturnInternalError(t *testing.T) {
@@ -206,7 +206,7 @@ func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNi
 
 	_, err := unit.entrypoint(mockInvocationContext, nil)
 
-	require.EqualError(t, err, expectedErrorMessage)
+	require.ErrorContains(t, err, expectedErrorMessage)
 }
 
 func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNilAndPayloadConvertToByteArrayAndTheByteArrayIsNotEmptyAndUnableToMatchDepGraphData_ShouldReturnInternalError(t *testing.T) {
@@ -223,7 +223,7 @@ func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNi
 
 	_, err := unit.entrypoint(mockInvocationContext, nil)
 
-	require.EqualError(t, err, expectedErrorMessage)
+	require.ErrorContains(t, err, expectedErrorMessage)
 }
 
 func Test_Entrypoint_GivenLegacyCliWorkflowReturnDataArray_AndDataIsNotEmptyOrNilAndPayloadConvertToByteArrayAndTheByteArrayIsNotEmptyAndMatchMultipleDepGraphData_ShouldReturnWorkflowDataWithMultipleDepGraphsAndDepGraphsMetadata(t *testing.T) {

--- a/internal/workflows/depgraph/errors/errors.go
+++ b/internal/workflows/depgraph/errors/errors.go
@@ -1,0 +1,77 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+
+	containererrors "github.com/snyk/container-cli/internal/common/errors"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+const DepGraphWorkflowUsrMsg = "an error occurred while running the underlying analysis needed to generate the depgraph"
+const (
+	EmptyLegacyDepGraphWorkflowPayloadResponseErrorCode = iota
+	CouldNotConvertPayloadErrorCode
+	CouldNotExtractOutputErrorCode
+	EmptyOutputErrorCode
+	ZeroMatchesMalformedOutputErrorCode
+)
+
+func newDepGraphWorkflowError(err error, userMsg string, errCode int) *containererrors.ContainerExtensionError {
+	return containererrors.NewContainerExtensionError(
+		err, userMsg, errCode, containererrors.DepGraphWorkflowErrCode,
+	)
+}
+
+func NewEmptyLegacyDepGraphWorkflowPayloadResponseError(data []workflow.Data) *containererrors.ContainerExtensionError {
+	return newDepGraphWorkflowError(
+		fmt.Errorf("empty legacy depgraph workflow payload response (payload: %s)", data),
+		DepGraphWorkflowUsrMsg,
+		EmptyLegacyDepGraphWorkflowPayloadResponseErrorCode,
+	)
+}
+
+func NewCouldNotConvertPayloadError(payload interface{}) *containererrors.ContainerExtensionError {
+	return newDepGraphWorkflowError(
+		fmt.Errorf("could not convert payload, expected []byte, but got '%T'", payload),
+		DepGraphWorkflowUsrMsg,
+		CouldNotConvertPayloadErrorCode,
+	)
+}
+
+func NewCouldNotExtractOutputError(err error) *containererrors.ContainerExtensionError {
+	return newDepGraphWorkflowError(
+		fmt.Errorf("could not extract depGraphs from CLI output: %w", err),
+		DepGraphWorkflowUsrMsg,
+		CouldNotExtractOutputErrorCode,
+	)
+}
+
+func NewEmptyOutputError() *containererrors.ContainerExtensionError {
+	return newDepGraphWorkflowError(
+		fmt.Errorf("empty output"),
+		DepGraphWorkflowUsrMsg,
+		EmptyOutputErrorCode,
+	)
+}
+
+func NewZeroMatchesMalformedOutputError() *containererrors.ContainerExtensionError {
+	return newDepGraphWorkflowError(
+		fmt.Errorf("malformed output, got 0 matches"),
+		DepGraphWorkflowUsrMsg,
+		ZeroMatchesMalformedOutputErrorCode,
+	)
+}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

add error code number to depgraph errors 

### Notes for the reviewer

Error code number is the line number from where the error created.
