### PR TITLE
feat: add cyclonedx 1.5 to sbomconstants.SbomValidFormats

### DIFF
--- a/internal/workflows/sbom/constants/constants.go
+++ b/internal/workflows/sbom/constants/constants.go
@@ -17,5 +17,7 @@ package constants
 var SbomValidFormats = []string{
 	"cyclonedx1.4+json",
 	"cyclonedx1.4+xml",
+	"cyclonedx1.5+json",
+	"cyclonedx1.5+xml",
 	"spdx2.3+json",
 }

--- a/internal/workflows/sbom/testdata/sbom_result_doc_cyclonedx_15.json
+++ b/internal/workflows/sbom/testdata/sbom_result_doc_cyclonedx_15.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "<<SERIAL_NUMBER>>",
+  "version": 1,
+  "metadata": {
+    "timestamp": "<<TIMESTAMP>>",
+    "tools": {
+      "services": [
+        {
+          "provider": {
+            "name": "Snyk"
+          },
+          "name": "Snyk Container"
+          "version": "1.0.0"
+        }
+      ]
+    },
+    "component": {
+      "bom-ref": "1-alpine@3.17.0",
+      "type": "container",
+      "name": "alpine",
+      "version": "3.17.0"
+      "purl": "pkg:apk/alpine/containers-common@0.50.1-r0?distro=3.17.2"
+    }
+  }
+}


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add support to request SBOMs in CycloneDX version 1.5.
