### PR TITLE
fix(79368): Fix a Bug when generating SBOM for container images using…

### DIFF
--- a/internal/workflows/sbom/archiveUtils.go
+++ b/internal/workflows/sbom/archiveUtils.go
@@ -1,0 +1,56 @@
+package sbom
+
+import (
+	"path"
+	"strings"
+)
+
+type ImageType int
+
+const (
+	DockerArchive ImageType = iota
+	OciArchive
+	Identifier
+)
+
+// Ported from https://github.com/snyk/snyk-docker-plugin/blob/b24ef0016347a98338535915ce5fc319e45c55e8/lib/image-type.ts#L4-L16
+func GetImageType(targetImage string) ImageType {
+	imageIdentifier := strings.Split(targetImage, ":")[0]
+	switch imageIdentifier {
+	case "docker-archive":
+		return DockerArchive
+	case "oci-archive":
+		return OciArchive
+	default:
+		return Identifier
+	}
+}
+
+// Ported from https://github.com/snyk/snyk-docker-plugin/blob/b24ef0016347a98338535915ce5fc319e45c55e8/lib/dependency-tree/index.ts#L15-L42
+func GetImageAndVersionFromFilePath(targetImage string) (string, string) {
+	targetImage = path.Base(targetImage)
+	imageName := targetImage
+	imageVersion := "latest"
+
+	finalSlash := strings.LastIndex(targetImage, "/")
+	hasVersion := (finalSlash >= 0 && strings.Contains(targetImage[finalSlash:], ":")) || strings.Contains(targetImage, ":")
+
+	if hasVersion {
+		versionSeparator := strings.LastIndex(targetImage, ":")
+		imageName = targetImage[:versionSeparator]
+		imageVersion = targetImage[versionSeparator+1:]
+	}
+
+	if strings.HasSuffix(imageVersion, ".tar") {
+		imageVersion = strings.TrimSuffix(imageVersion, ".tar")
+	}
+
+	shaString := "@sha256"
+
+	if strings.HasSuffix(imageName, shaString) {
+		imageName = imageName[:len(imageName)-len(shaString)]
+		imageVersion = ""
+	}
+
+	return imageName, imageVersion
+}

--- a/internal/workflows/sbom/depgraph.go
+++ b/internal/workflows/sbom/depgraph.go
@@ -24,6 +24,12 @@ import (
 )
 
 func depGraphMetadata(imgName string) (name, version string, err error) {
+	// If the scan is on archive files
+	imgType := GetImageType(imgName)
+	if imgType == DockerArchive || imgType == OciArchive {
+		imgName, version = GetImageAndVersionFromFilePath(imgName)
+		return imgName, version, nil
+	}
 	// we currently don't have a way of extracting the clean image name & potentially a digest from
 	// the DepGraph output, so we use what's been passed on the command line.
 	ref, err := reference.Parse(imgName)


### PR DESCRIPTION
… absolute / Relative path

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
There is bug on snyk container SBOM. When the SBOM is generated on docker-archives, The scan fails with error 
`error while invoking depgraph workflow: could not parse container name: invalid reference format`
We created a support ticket with SNyk with request ID 79368. 

This PR tries to fix the said bug to allow SBOM generation on archive files with absolute / relative path. 

_Explain why this PR exists_

https://github.com/snyk/container-cli/blob/6d9b9482f9b12d106d6feeffa1d1c2fcfca8a8a7/internal/workflows/sbom/depgraph.go#L29 fails when image name contain file paths. This possible fix can be either sanitise the imageName or conditionally handle scan with paths (AKA archvie scans) . This PR handles this the second way.


### Notes for the reviewer
I haven't tested this. Since I can't find the contribution guide or how to build or test this repo.  Please feel free to contribute to this PR. Or feedback whats needed from me.

_Instructions on how to run this locally, background context, what to review, questions…_
