### PR TITLE
feat: add CycloneDX 1.6 support

### DIFF
--- a/internal/workflows/sbom/constants/constants.go
+++ b/internal/workflows/sbom/constants/constants.go
@@ -19,5 +19,7 @@ var SbomValidFormats = []string{
 	"cyclonedx1.4+xml",
 	"cyclonedx1.5+json",
 	"cyclonedx1.5+xml",
+	"cyclonedx1.6+json",
+	"cyclonedx1.6+xml",
 	"spdx2.3+json",
 }

--- a/internal/workflows/sbom/sbom_test.go
+++ b/internal/workflows/sbom/sbom_test.go
@@ -154,6 +154,8 @@ func Test_Entrypoint_GivenSbomForDepGraphError_ShouldPropagateClientError(t *tes
 			format: "cyclonedx1.4+json",
 		}, "CycloneDX 1.5 JSON": {
 			format: "cyclonedx1.5+json",
+		}, "CycloneDX 1.6 JSON": {
+			format: "cyclonedx1.6+json",
 		},
 	}
 
@@ -206,6 +208,9 @@ func Test_Entrypoint_GivenNoError_ShouldReturnSbomAsWorkflowData(t *testing.T) {
 		}, "CycloneDX 1.5 JSON": {
 			format:      "cyclonedx1.5+json",
 			expectedDoc: "testdata/sbom_result_doc_cyclonedx_15.json",
+		}, "CycloneDX 1.6 JSON": {
+			format:      "cyclonedx1.6+json",
+			expectedDoc: "testdata/sbom_result_doc_cyclonedx_16.json",
 		},
 	}
 

--- a/internal/workflows/sbom/testdata/sbom_result_doc_cyclonedx_16.json
+++ b/internal/workflows/sbom/testdata/sbom_result_doc_cyclonedx_16.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
+  "specVersion": "1.6",
   "serialNumber": "<<SERIAL_NUMBER>>",
   "version": 1,
   "metadata": {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds `CycloneDX 1.6` in the list of supported SBOM formats now that the hidden endpoint also supports this format.
