### PR TITLE
feat: accept plugin flag

### DIFF
--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/errors/error.go
+++ b/internal/common/errors/error.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/errors/error_factory.go
+++ b/internal/common/errors/error_factory.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/errors/errors.go
+++ b/internal/common/errors/errors.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/base_flag.go
+++ b/internal/common/flags/base_flag.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/base_flag_test.go
+++ b/internal/common/flags/base_flag_test.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/bool_flag.go
+++ b/internal/common/flags/bool_flag.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/bool_flag_test.go
+++ b/internal/common/flags/bool_flag_test.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/flag.go
+++ b/internal/common/flags/flag.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/flags.go
+++ b/internal/common/flags/flags.go
@@ -31,4 +31,12 @@ var (
 		"",
 		fmt.Sprintf("Specify the SBOM output format. %s", constants.SbomValidFormats),
 	)
+	FlagPlatform = NewStringFlag(
+		"platform",
+		"",
+		fmt.Sprintf(
+			"For multi-architecture images, specify the platform for the container image. %s",
+			constants.ValidPlatforms,
+		),
+	)
 )

--- a/internal/common/flags/flags.go
+++ b/internal/common/flags/flags.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/string_flag.go
+++ b/internal/common/flags/string_flag.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/flags/string_flag_test.go
+++ b/internal/common/flags/string_flag_test.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/workflows/base_workflow.go
+++ b/internal/common/workflows/base_workflow.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/depgraph/depgraph.go
+++ b/internal/workflows/depgraph/depgraph.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/depgraph/depgraph.go
+++ b/internal/workflows/depgraph/depgraph.go
@@ -67,6 +67,10 @@ func (d *DepGraphWorkflow) entrypoint(ictx workflow.InvocationContext, _ []workf
 	logger.Info().Msg("starting the depgraph workflow")
 
 	baseCmdArgs := []string{"container", "test", "--print-graph", "--json"}
+	platform := flags.FlagPlatform.GetFlagValue(config)
+	if platform != "" {
+		baseCmdArgs = append(baseCmdArgs, fmt.Sprintf("--platform=%s", platform))
+	}
 	cmdArgs := buildCliCommand(baseCmdArgs, d.Flags, config)
 
 	logger.Info().Msgf("cli invocation args: %v", cmdArgs)

--- a/internal/workflows/depgraph/depgraph_test.go
+++ b/internal/workflows/depgraph/depgraph_test.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/depgraph/depgraph_test.go
+++ b/internal/workflows/depgraph/depgraph_test.go
@@ -277,6 +277,7 @@ func Test_InitWorkflow_GivenFlags_ShouldRegisterFlagsToWorkflowAndReturnThemInCo
 }
 
 func initMocks() {
+	mockConfig.EXPECT().GetString(flags.FlagPlatform.Name).Return("")
 	mockConfig.EXPECT().GetBool(flags.FlagExcludeAppVulns.Name).Return(false)
 	mockConfig.EXPECT().GetString(constants.ContainerTargetArgName).Return(testContainerTargetArg)
 	mockConfig.EXPECT().Set(configuration.RAW_CMD_ARGS, gomock.AssignableToTypeOf([]string{}))
@@ -285,7 +286,7 @@ func initMocks() {
 	mockInvocationContext.EXPECT().GetEnhancedLogger().Return(logger)
 }
 
-func buildData(identifier workflow.Identifier, payload interface{}, target string) workflow.Data {
+func buildData(identifier workflow.Identifier, payload any, target string) workflow.Data {
 	d := workflow.NewData(identifier, constants.ContentTypeJSON, payload)
 	d.SetMetaData(constants.HeaderContentLocation, target)
 

--- a/internal/workflows/sbom/constants/constants.go
+++ b/internal/workflows/sbom/constants/constants.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/constants/constants.go
+++ b/internal/workflows/sbom/constants/constants.go
@@ -23,3 +23,14 @@ var SbomValidFormats = []string{
 	"cyclonedx1.6+xml",
 	"spdx2.3+json",
 }
+
+var ValidPlatforms = []string{
+	"linux/amd64",
+	"linux/arm64",
+	"linux/riscv64",
+	"linux/ppc64le",
+	"linux/s390x",
+	"linux/386",
+	"linux/arm/v7",
+	"linux/arm/v6",
+}

--- a/internal/workflows/sbom/depgraph.go
+++ b/internal/workflows/sbom/depgraph.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/errors/errors.go
+++ b/internal/workflows/sbom/errors/errors.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/errors/errors.go
+++ b/internal/workflows/sbom/errors/errors.go
@@ -59,6 +59,20 @@ func (ef *SbomErrorFactory) NewInvalidSbomFormatError(
 	)
 }
 
+func (ef *SbomErrorFactory) NewInvalidPlatformError(
+	invalid string, validPlatforms []string,
+) *containererrors.ContainerExtensionError {
+	return ef.NewError(
+		fmt.Errorf("invalid platform provided (%s)", invalid),
+		fmt.Sprintf(
+			"The platform provided (%s) is not one of the available platforms. "+
+				"Available platforms are: %s",
+			invalid,
+			strings.Join(validPlatforms, ", "),
+		),
+	)
+}
+
 func (ef *SbomErrorFactory) NewDepGraphWorkflowError(err error) *containererrors.ContainerExtensionError {
 	return ef.NewError(
 		fmt.Errorf("error while invoking depgraph workflow: %w", err),

--- a/internal/workflows/sbom/http_sbom_client.go
+++ b/internal/workflows/sbom/http_sbom_client.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/http_sbom_client_test.go
+++ b/internal/workflows/sbom/http_sbom_client_test.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/http_sbom_client_test.go
+++ b/internal/workflows/sbom/http_sbom_client_test.go
@@ -39,7 +39,8 @@ var (
 
 func Test_GetSbomForDepGraph_GivenNoError_ShouldReturnSbom(t *testing.T) {
 	type test struct {
-		format string
+		format   string
+		platform string
 	}
 
 	tests := map[string]test{
@@ -97,7 +98,7 @@ func Test_GetSbomForDepGraph_GivenNoError_ShouldReturnSbom(t *testing.T) {
 				ErrFactory: sbomerrors.NewSbomErrorFactory(&zlog.Logger),
 			})
 
-			res, err := client.GetSbomForDepGraph(context.Background(), orgID, tc.format, &req)
+			res, err := client.GetSbomForDepGraph(context.Background(), orgID, tc.format, tc.platform, &req)
 			require.NoError(t, err)
 
 			require.Equal(t, &GetSbomForDepGraphResult{

--- a/internal/workflows/sbom/interfaces.go
+++ b/internal/workflows/sbom/interfaces.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/interfaces.go
+++ b/internal/workflows/sbom/interfaces.go
@@ -22,5 +22,11 @@ import (
 
 // SbomClient provides SBOM generation operations
 type SbomClient interface {
-	GetSbomForDepGraph(context.Context, string, string, *GetSbomForDepGraphRequest) (*GetSbomForDepGraphResult, error)
+	GetSbomForDepGraph(
+		ctx context.Context,
+		orgID string,
+		format string,
+		platform string,
+		req *GetSbomForDepGraphRequest,
+	) (*GetSbomForDepGraphResult, error)
 }

--- a/internal/workflows/sbom/interfaces_mocks.go
+++ b/internal/workflows/sbom/interfaces_mocks.go
@@ -35,16 +35,16 @@ func (m *MockSbomClient) EXPECT() *MockSbomClientMockRecorder {
 }
 
 // GetSbomForDepGraph mocks base method.
-func (m *MockSbomClient) GetSbomForDepGraph(arg0 context.Context, arg1, arg2 string, arg3 *GetSbomForDepGraphRequest) (*GetSbomForDepGraphResult, error) {
+	func (m *MockSbomClient) GetSbomForDepGraph(ctx context.Context, orgID string, format string, platform string, req *GetSbomForDepGraphRequest) (*GetSbomForDepGraphResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSbomForDepGraph", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetSbomForDepGraph", ctx, orgID, format, platform, req)
 	ret0, _ := ret[0].(*GetSbomForDepGraphResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSbomForDepGraph indicates an expected call of GetSbomForDepGraph.
-func (mr *MockSbomClientMockRecorder) GetSbomForDepGraph(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockSbomClientMockRecorder) GetSbomForDepGraph(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSbomForDepGraph", reflect.TypeOf((*MockSbomClient)(nil).GetSbomForDepGraph), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSbomForDepGraph", reflect.TypeOf((*MockSbomClient)(nil).GetSbomForDepGraph), arg0, arg1, arg2, arg3, arg4)
 }

--- a/internal/workflows/sbom/sbom.go
+++ b/internal/workflows/sbom/sbom.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/sbom.go
+++ b/internal/workflows/sbom/sbom.go
@@ -46,6 +46,7 @@ func NewWorkflow(sbomClient SbomClient, errFactory *sbomerrors.SbomErrorFactory)
 			Flags: []flags.Flag{
 				flags.FlagSbomFormat,
 				flags.FlagExcludeAppVulns,
+				flags.FlagPlatform,
 			},
 		},
 		depGraph:   containerdepgraph.Workflow,
@@ -76,6 +77,12 @@ func (w *Workflow) entrypoint(ictx workflow.InvocationContext, _ []workflow.Data
 		return nil, err
 	}
 
+	logger.Debug().Msg("getting the platform")
+	var platform = flags.FlagPlatform.GetFlagValue(config)
+	if err := validatePlatform(platform, sbomconstants.ValidPlatforms, w.errFactory); err != nil {
+		return nil, err
+	}
+
 	logger.Debug().Msg("getting preferred organization id")
 	orgID := config.GetString(configuration.ORGANIZATION)
 	if orgID == "" {
@@ -100,13 +107,19 @@ func (w *Workflow) entrypoint(ictx workflow.InvocationContext, _ []workflow.Data
 		return nil, w.errFactory.NewDepGraphWorkflowError(err)
 	}
 
-	sbomResult, err := w.sbomClient.GetSbomForDepGraph(context.Background(), orgID, format, &GetSbomForDepGraphRequest{
-		DepGraphs: depGraphsBytes,
-		Subject: Subject{
-			Name:    imageName,
-			Version: imageVersion,
+	sbomResult, err := w.sbomClient.GetSbomForDepGraph(
+		context.Background(),
+		orgID,
+		format,
+		platform,
+		&GetSbomForDepGraphRequest{
+			DepGraphs: depGraphsBytes,
+			Subject: Subject{
+				Name:    imageName,
+				Version: imageVersion,
+			},
 		},
-	})
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -130,5 +143,12 @@ func validateSBOMFormat(candidate string, sbomFormats []string, errFactory *sbom
 		return errFactory.NewInvalidSbomFormatError(candidate, sbomFormats)
 	}
 
+	return nil
+}
+
+func validatePlatform(candidate string, platforms []string, errFactory *sbomerrors.SbomErrorFactory) error {
+	if candidate != "" && !slices.Contains(platforms, candidate) {
+		return errFactory.NewInvalidPlatformError(candidate, platforms)
+	}
 	return nil
 }

--- a/internal/workflows/sbom/sbom_test.go
+++ b/internal/workflows/sbom/sbom_test.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/workflows/sbom/sbom_test.go
+++ b/internal/workflows/sbom/sbom_test.go
@@ -146,7 +146,8 @@ func Test_Entrypoint_GivenInvalidDepGraphPayloadType_ShouldReturnDepGraphWorkflo
 
 func Test_Entrypoint_GivenSbomForDepGraphError_ShouldPropagateClientError(t *testing.T) {
 	type test struct {
-		format string
+		format   string
+		platform string
 	}
 
 	tests := map[string]test{
@@ -182,6 +183,7 @@ func Test_Entrypoint_GivenSbomForDepGraphError_ShouldPropagateClientError(t *tes
 				gomock.Any(),
 				"aaacbb21-19b4-44f4-8483-d03746156f6b",
 				tc.format,
+				tc.platform,
 				&GetSbomForDepGraphRequest{
 					DepGraphs: getDepGraphBytes(depGraphList),
 					Subject: Subject{
@@ -198,7 +200,7 @@ func Test_Entrypoint_GivenSbomForDepGraphError_ShouldPropagateClientError(t *tes
 
 func Test_Entrypoint_GivenNoError_ShouldReturnSbomAsWorkflowData(t *testing.T) {
 	type test struct {
-		format, expectedDoc string
+		format, platform, expectedDoc string
 	}
 
 	tests := map[string]test{
@@ -238,6 +240,7 @@ func Test_Entrypoint_GivenNoError_ShouldReturnSbomAsWorkflowData(t *testing.T) {
 				gomock.Any(),
 				"aaacbb21-19b4-44f4-8483-d03746156f6b",
 				tc.format,
+				tc.platform,
 				&GetSbomForDepGraphRequest{
 					DepGraphs: getDepGraphBytes(depGraphList),
 					Subject: Subject{

--- a/internal/workflows/sbom/types.go
+++ b/internal/workflows/sbom/types.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/container/container_cli.go
+++ b/pkg/container/container_cli.go
@@ -1,4 +1,4 @@
-// © 2023-2024 Snyk Limited All rights reserved.
+// © 2023-2025 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds a `--platform` flag to the `container sbom` command. The value for the platform is passed through to the `container test` command, and results in the SBOM specifically for that platform.

Once this PR is merged I'll update [this draft PR](https://github.com/snyk/cli/pull/5788) to pull in the updated `container-cli` version to the `cli` repo.

### Notes for the reviewer

To test, build the CLI pointing to this branch of `container-cli`, and run it with the arguments

```sh
container sbom --format spdx2.3+json nginx:latest --platform=linux/amd64
```

Test with different values for `--platform`, e.g. `linux/386`, and you should see different results.