### PR TITLE
chore: bump Go version to 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 go_image: &go_image
   resource_class: medium
   docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.24
 
 node_image: &node_image
   resource_class: small

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,8 @@ linters:
     - asasalint
     # checks for dangerous unicode character sequences
     - bidichk
+    # detects places where loop variables are copied
+    - copyloopvar
     # checks whether HTTP response body is closed successfully
     #- bodyclose # not supported on Go >=1.18
     # code clone detection
@@ -12,8 +14,6 @@ linters:
     - errcheck
     # checks for problematic error-wrapping code
     - errorlint
-    # checks for pointers to enclosing loop vars.
-    - exportloopref
     # computes & checks the cognitive complexity of functions
     - gocognit
     # finds repeated strings that could be replaced by constant

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/container-cli
 
-go 1.21
+go 1.24
 
 require (
 	github.com/docker/distribution v2.8.2+incompatible

--- a/internal/workflows/sbom/sbom.go
+++ b/internal/workflows/sbom/sbom.go
@@ -16,9 +16,7 @@ package sbom
 
 import (
 	"context"
-
-	// TODO: migrate this to `slices` package after CLI will be migrated to Go v1.21
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/snyk/container-cli/internal/common/constants"
 	"github.com/snyk/container-cli/internal/common/flags"


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests) - n/a
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation) - n/a
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

As shown [here](https://github.com/snyk/container-cli/pull/32) there are issues on main because a dependency requires at least Go version 1.23. This PR bumps it to the latest minor version of 1.24, and replaces the lint rule `exportloopref` with `copyloopvar` as the former has been deprecated.