### PR TITLE
feat: support tar archive inputs

### DIFF
--- a/internal/workflows/sbom/archive.go
+++ b/internal/workflows/sbom/archive.go
@@ -1,0 +1,58 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// archivePrefixes defines the supported archive URI prefixes.
+// These must stay in sync with snyk-docker-plugin/lib/image-type.ts (getImageType).
+var archivePrefixes = []string{
+	"docker-archive:",
+	"oci-archive:",
+	"kaniko-archive:",
+}
+
+// isArchiveInput returns true if the input is an archive reference,
+// either prefixed (docker-archive:, oci-archive:, kaniko-archive:) or ending in .tar.
+func isArchiveInput(input string) bool {
+	for _, prefix := range archivePrefixes {
+		if strings.HasPrefix(input, prefix) {
+			return true
+		}
+	}
+	return strings.HasSuffix(input, ".tar")
+}
+
+// archiveMetadata extracts a meaningful name and version from an archive input.
+// For archive inputs, the name is derived from the file basename (including the
+// .tar extension), and the version is left empty. This is consistent with how
+// snyk-docker-plugin derives image identifiers and existing v1 behavior.
+func archiveMetadata(input string) (name, version string) {
+	path := input
+
+	// Strip known archive prefixes to get the file path.
+	for _, prefix := range archivePrefixes {
+		if strings.HasPrefix(input, prefix) {
+			path = input[len(prefix):]
+			break
+		}
+	}
+
+	name = filepath.Base(path)
+	return name, ""
+}

--- a/internal/workflows/sbom/archive_test.go
+++ b/internal/workflows/sbom/archive_test.go
@@ -1,0 +1,97 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsArchiveInput(t *testing.T) {
+	type test struct {
+		input    string
+		expected bool
+	}
+
+	tests := map[string]test{
+		// Archive prefixes
+		"docker-archive with absolute path": {"docker-archive:/path/to/image.tar", true},
+		"docker-archive with filename":      {"docker-archive:image.tar", true},
+		"docker-archive with relative path": {"docker-archive:relative/path/image.tar", true},
+		"oci-archive with absolute path":    {"oci-archive:/path/to/image.tar", true},
+		"oci-archive with filename":         {"oci-archive:image.tar", true},
+		"kaniko-archive with absolute path": {"kaniko-archive:/path/to/image.tar", true},
+		"kaniko-archive with filename":      {"kaniko-archive:image.tar", true},
+
+		// Bare .tar files
+		"absolute path .tar": {"/path/to/image.tar", true},
+		"filename .tar":      {"image.tar", true},
+		"relative path .tar": {"./relative/image.tar", true},
+
+		// Non-archive inputs
+		"image with tag":          {"nginx:latest", false},
+		"image with version":      {"alpine:3.17.0", false},
+		"registry image with tag": {"registry.example.com/repo:tag", false},
+		"bare image name":         {"ubuntu", false},
+		"empty string":            {"", false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := isArchiveInput(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestArchiveMetadata(t *testing.T) {
+	type test struct {
+		input        string
+		expectedName string
+		expectedVer  string
+	}
+
+	tests := map[string]test{
+		// docker-archive prefix — name retains .tar extension (matches v1 behavior)
+		"docker-archive absolute path": {"docker-archive:/var/tmp/nginx.tar", "nginx.tar", ""},
+		"docker-archive nested path":   {"docker-archive:/path/to/my-image.tar", "my-image.tar", ""},
+		"docker-archive filename only": {"docker-archive:image.tar", "image.tar", ""},
+
+		// oci-archive prefix
+		"oci-archive absolute path": {"oci-archive:/path/to/image.tar", "image.tar", ""},
+		"oci-archive relative path": {"oci-archive:relative/path/app.tar", "app.tar", ""},
+
+		// kaniko-archive prefix
+		"kaniko-archive absolute path": {"kaniko-archive:/path/to/image.tar", "image.tar", ""},
+		"kaniko-archive filename only": {"kaniko-archive:build-output.tar", "build-output.tar", ""},
+
+		// Bare .tar files
+		"bare absolute path": {"/path/to/image.tar", "image.tar", ""},
+		"bare filename":      {"image.tar", "image.tar", ""},
+		"bare relative path": {"./relative/image.tar", "image.tar", ""},
+
+		// Non-.tar extension with prefix (e.g. .tar.gz)
+		"docker-archive tar.gz": {"docker-archive:/path/to/image.tar.gz", "image.tar.gz", ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			name, version := archiveMetadata(tc.input)
+			require.Equal(t, tc.expectedName, name)
+			require.Equal(t, tc.expectedVer, version)
+		})
+	}
+}

--- a/internal/workflows/sbom/depgraph.go
+++ b/internal/workflows/sbom/depgraph.go
@@ -24,6 +24,13 @@ import (
 )
 
 func depGraphMetadata(imgName string) (name, version string, err error) {
+	// Archive inputs (docker-archive:, oci-archive:, kaniko-archive:, *.tar) cannot be
+	// parsed by the Docker distribution reference library. Handle them separately.
+	if isArchiveInput(imgName) {
+		name, version = archiveMetadata(imgName)
+		return name, version, nil
+	}
+
 	// we currently don't have a way of extracting the clean image name & potentially a digest from
 	// the DepGraph output, so we use what's been passed on the command line.
 	ref, err := reference.Parse(imgName)


### PR DESCRIPTION
### Summary
This PR adds support for tar archive inputs in the `snyk container sbom` workflow, bringing it to parity with `snyk container test`.

### Changes
- Creates `archive.go` with `isArchiveInput()` to detect archive references (by `docker-archive:`, `oci-archive:`, `kaniko-archive:` prefix or `.tar` suffix) and `archiveMetadata()` to extract a meaningful subject name from the archive file path
- Adds an early return in `depGraphMetadata()` that handles archive inputs before calling `reference.Parse()`, which only supports Docker registry-style image references
- Adds unit tests for all archive detection and metadata extraction cases, including all three prefixes, bare `.tar` paths, and non-archive negative cases
- Adds integration tests verifying the full SBOM entrypoint flow with archive inputs, confirming the correct Subject name and version are passed to the SBOM API

### Context
The `snyk container sbom` workflow invokes the legacy v1 CLI (`snyk container test --print-graph`) to generate a depgraph, which already handles archive inputs via `snyk-docker-plugin`. However, after the depgraph is returned, `depGraphMetadata()` calls `reference.Parse()` from the Docker distribution library to extract the SBOM subject name and version. This library only handles registry-style image references (`nginx:latest`) and fails on file paths (`/path/to/image.tar`) and archive URIs (`docker-archive:/path/to/file`). The fix detects archive inputs before reaching `reference.Parse()` and derives the subject name from the file basename, consistent with how `snyk-docker-plugin` derives image identifiers in v1.

### Related
JIRA: [CN-680](https://snyksec.atlassian.net/browse/CN-680)

[CN-680]: https://snyksec.atlassian.net/browse/CN-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ