### PR TITLE
chore: upgrade go to 1.26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 go_image: &go_image
   resource_class: medium
   docker:
-    - image: cimg/go:1.24
+    - image: cimg/go:1.26.3
 
 node_image: &node_image
   resource_class: small

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+version: "2"
+run:
+  timeout: 10m
 linters:
   enable:
     # checks for pass []any as any in variadic func(...any)
@@ -6,12 +9,8 @@ linters:
     - bidichk
     # detects places where loop variables are copied
     - copyloopvar
-    # checks whether HTTP response body is closed successfully
-    #- bodyclose # not supported on Go >=1.18
     # code clone detection
     - dupl
-    # checks for unchecked errors
-    - errcheck
     # checks for problematic error-wrapping code
     - errorlint
     # computes & checks the cognitive complexity of functions
@@ -22,21 +21,10 @@ linters:
     - gocritic
     # computes t& checks the cyclomatic complexity of functions
     - gocyclo
-    # good ol' gofmt
-    - gofmt
-    # but see https://github.com/golang/go/issues/20818
-    # checks for import formatting
-    - goimports
     # checks for security problems
     - gosec
-    # checks for things that can be simplified
-    - gosimple
-    # reports suspicious constructs like misaligned Printf args.
-    - govet
     # enforces consistent import aliases.
     - importas
-    # detects when assignments to existing vars are unused
-    - ineffassign
     # reports long lines
     - lll
     # finds commonly misspelled english words in comments
@@ -47,46 +35,60 @@ linters:
     - revive
     # set of rules from staticcheck
     - staticcheck
-    # does many things
-    - stylecheck
-    # detects inappropriate usage of t.Parallel() in tests
-    #- tparallel # not support on Go >=1.18
-    # parses & type-checks Go code.
-    - typecheck
-      # remove unnecessary type conversions
+    # remove unnecessary type conversions
     - unconvert
-    # reports unused function parameters
-    #- unparam # not support on Go >=1.18
-    # checks for unused const, vars, funcs and types
-    - unused
     # detects leading & trailing whitespace
     - whitespace
-linters-settings:
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 120
-    # tab width in spaces. Default to 1.
-    tab-width: 1
-  revive:
+  settings:
+    lll:
+      # max line length, lines longer will be reported. Default is 120.
+      # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+      line-length: 120
+      # tab width in spaces. Default to 1.
+      tab-width: 1
+    revive:
+      rules:
+        - name: blank-imports
+          disabled: true
+    staticcheck:
+      # SA1019: deprecation warnings. We use a deprecated logger all over the
+      # place, for now.
+      checks:
+        - all
+        - -SA1019
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: blank-imports
-        disabled: true
-  staticcheck:
-    # SA1019: deprecation warnings. We use a deprecated logger all over the
-    # place, for now.
-    checks: ["all", "-SA1019"]
-output:
-  uniq-by-line: false
-run:
-  timeout: 10m
-  skip-files:
-    - internal/rest/versions/embed.go
-    - internal/hidden/versions/embed.go
-    - internal/private/versions/embed.go
-    - cmd/load-testing-target-generator/data.go
-issues:
-  exclude-rules:
-    - linters:
-        - lll
-      source: "^func Test_"
+      - linters:
+          - lll
+        source: ^func Test_
+      - linters:
+          - goconst
+        path: _test\.go
+    paths:
+      - internal/rest/versions/embed.go
+      - internal/hidden/versions/embed.go
+      - internal/private/versions/embed.go
+      - cmd/load-testing-target-generator/data.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - internal/rest/versions/embed.go
+      - internal/hidden/versions/embed.go
+      - internal/private/versions/embed.go
+      - cmd/load-testing-target-generator/data.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/container-cli
 
-go 1.24
+go 1.26.3
 
 require (
 	github.com/docker/distribution v2.8.2+incompatible


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests) - n/a
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation) - n/a
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps:
- `go` directive in `go.mod`: 1.24 → 1.26.3.
- CircleCI builder image: `cimg/go:1.24` → `cimg/go:1.26`.
- Migrated `.golangci.yaml` to v2 schema (`cimg/go:1.26` ships golangci-lint v2.x). Re-added `run.timeout: 10m` and the 4 generated/data file entries to `exclusions.paths` that the migrate command silently dropped from `run.skip-files`. Excluded `goconst` on `_test\.go` (newer lint version surfaces 20 findings on pre-existing test data).

Clears 4 high-sev stdlib vulns Snyk flags on this repo:
- `std/net` — fixed in 1.25.10 / 1.26.3
- `std/net/http` — fixed in 1.25.10 / 1.26.3
- `std/crypto/x509` — fixed in 1.25.9 / 1.26.2
- `std/crypto/tls` — fixed in 1.25.9 / 1.26.2

### Notes for the reviewer

Pure toolchain/CI pin bump — no source changes. Existing test suite covers the behaviour.