### PR TITLE
chore: update unify mentions to container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ workflows:
           <<: *branch_exclude_main
       - security-scans:
           name: Security Scans
-          context: analysis_unify
+          context: infrasec_container
           <<: *branch_exclude_main
       - unit_test:
           name: Unit Tests + Coverage
@@ -86,7 +86,7 @@ workflows:
           name: Secrets scan
           context:
             - snyk-bot-slack
-          channel: snyk-vuln-alerts-unify
+          channel: team-container-alerts
           <<: *branch_exclude_main
       - commitlint/lint:
           name: Commit Lint
@@ -100,7 +100,7 @@ workflows:
     jobs:
       - security-scans:
           name: Security Scans
-          context: analysis_unify
+          context: infrasec_container
           <<: *branch_only_main
       - lint:
           name: Lint

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: container-cli
   annotations:
     github.com/project-slug: snyk/container-cli
-    github.com/team-slug: snyk/unify
+    github.com/team-slug: snyk/container_container
 spec:
   type: snyk-cli-plugin
   lifecycle: "-"
-  owner: unify
+  owner: container


### PR DESCRIPTION
### What this does

Update mentions of unify to container as unify are still receiving vuln alerts and remediation tickets from prodsec

