### PR TITLE
feat(cn-1471): scan-result envelope writer and dragonfly error types

### DIFF
--- a/internal/workflows/test/errors.go
+++ b/internal/workflows/test/errors.go
@@ -1,0 +1,58 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SkippedFilesError is returned when the File Upload API silently dropped one
+// or more ScanResult files. Proceeding against an incomplete revision would
+// produce a partial test with no protocol-level indication of what was
+// missing, so the dragonfly flow aborts before calling StartTest.
+type SkippedFilesError struct {
+	Paths []string
+}
+
+func (e *SkippedFilesError) Error() string {
+	return fmt.Sprintf("file upload skipped %d file(s): %s", len(e.Paths), strings.Join(e.Paths, ", "))
+}
+
+// ComponentFailureError is returned when one or more per-component tests
+// errored on the platform side. container-engine reports per-component
+// failures via Component.Success=false; the CLI escalates any such failure
+// to a total test failure so the customer sees an all-or-nothing result.
+// Details carries the platform-supplied error detail strings for diagnostic
+// surfacing.
+type ComponentFailureError struct {
+	Details []string
+}
+
+func (e *ComponentFailureError) Error() string {
+	return fmt.Sprintf("test failed for %d component(s): %s", len(e.Details), strings.Join(e.Details, ", "))
+}
+
+// IncompleteFindingsError is returned when the FindingData pagination did
+// not drain to complete=true. A partial findings list would silently
+// underreport vulnerabilities to the customer. Received records how many
+// findings were drained before the abort so the operator can correlate.
+type IncompleteFindingsError struct {
+	Received int
+}
+
+func (e *IncompleteFindingsError) Error() string {
+	return fmt.Sprintf("findings pagination did not complete (%d findings received before abort)", e.Received)
+}

--- a/internal/workflows/test/errors_test.go
+++ b/internal/workflows/test/errors_test.go
@@ -1,0 +1,75 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SkippedFilesError surfaces every skipped path so the operator can act on them.
+func TestSkippedFilesError_MessageListsAllPaths(t *testing.T) {
+	err := &SkippedFilesError{Paths: []string{"a.json", "b.json"}}
+	assert.Contains(t, err.Error(), "a.json")
+	assert.Contains(t, err.Error(), "b.json")
+	assert.Contains(t, err.Error(), "2")
+}
+
+// Each error type is a standard error and survives errors.As unwrapping.
+func TestErrors_AreUnwrappableViaErrorsAs(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		into func() any
+	}{
+		{
+			name: "SkippedFilesError",
+			err:  &SkippedFilesError{Paths: []string{"x"}},
+			into: func() any { var v *SkippedFilesError; return &v },
+		},
+		{
+			name: "ComponentFailureError",
+			err:  &ComponentFailureError{Details: []string{"c"}},
+			into: func() any { var v *ComponentFailureError; return &v },
+		},
+		{
+			name: "IncompleteFindingsError",
+			err:  &IncompleteFindingsError{Received: 3},
+			into: func() any { var v *IncompleteFindingsError; return &v },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := tc.into()
+			require.True(t, errors.As(tc.err, target))
+		})
+	}
+}
+
+// ComponentFailureError surfaces the platform error details in its message.
+func TestComponentFailureError_NamesFailureDetails(t *testing.T) {
+	err := &ComponentFailureError{Details: []string{"os scan timed out", "npm scan unauthorized"}}
+	assert.Contains(t, err.Error(), "os scan timed out")
+	assert.Contains(t, err.Error(), "npm scan unauthorized")
+}
+
+// IncompleteFindingsError reports how many findings were drained before the abort.
+func TestIncompleteFindingsError_ReportsReceivedCount(t *testing.T) {
+	err := &IncompleteFindingsError{Received: 42}
+	assert.Contains(t, err.Error(), "42")
+}

--- a/internal/workflows/test/scan_result.go
+++ b/internal/workflows/test/scan_result.go
@@ -1,0 +1,86 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test implements the Dragonfly-path "snyk container test" workflow.
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// scanResultSchemaPrefix is the fixed prefix of the on-disk envelope's
+// schema field; the pluginVersion is appended to form the full schema value
+// (e.g. "snyk.container.scan_result.9.1.1"). Encoding the plugin version in
+// the schema string lets container-engine tell cohorts apart from the
+// envelope alone — the plugin version is what drives the scanResult JSON
+// shape. The engine reads pluginVersion authoritatively from the
+// scanResult's own pluginVersion fact; the schema suffix is a discriminator
+// on the envelope, not a source of truth.
+const scanResultSchemaPrefix = "snyk.container.scan_result."
+
+// ScanResultInput pairs one raw ScanResult JSON payload with the version of
+// snyk-docker-plugin that produced it. The plugin version is extracted from
+// the scanResult's PluginVersion fact upstream; empty string is acceptable
+// when the producing cohort predates the fact.
+type ScanResultInput struct {
+	ScanResult    json.RawMessage
+	PluginVersion string
+}
+
+// scanResultEnvelope is the on-disk wrapper for a single ScanResult inside an
+// UPLOAD_REVISION workspace. The {schema, scanResult} shape is an internal
+// contract between container-cli and container-engine; the engine validates
+// that schema starts with scanResultSchemaPrefix.
+type scanResultEnvelope struct {
+	Schema     string          `json:"schema"`
+	ScanResult json.RawMessage `json:"scanResult"`
+}
+
+// writeScanResultsTempDir writes each ScanResultInput to
+// <tmpDir>/scan_results/scan_result_<n>.json wrapped in the v1 envelope. It
+// returns the root temp directory (so the caller can defer os.RemoveAll) and
+// the list of file paths written. On error after MkdirTemp succeeds, the
+// caller still receives the temp dir name and is responsible for cleanup.
+func writeScanResultsTempDir(scanResults []ScanResultInput) (tmpDir string, filePaths []string, err error) {
+	tmpDir, err = os.MkdirTemp("", "container-scan-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+
+	subDir := filepath.Join(tmpDir, "scan_results")
+	if err = os.MkdirAll(subDir, 0o755); err != nil {
+		return tmpDir, nil, fmt.Errorf("creating scan_results subdirectory: %w", err)
+	}
+
+	filePaths = make([]string, 0, len(scanResults))
+	for i, input := range scanResults {
+		path := filepath.Join(subDir, fmt.Sprintf("scan_result_%d.json", i))
+		envelope := scanResultEnvelope{
+			Schema:     scanResultSchemaPrefix + input.PluginVersion,
+			ScanResult: input.ScanResult,
+		}
+		body, marshalErr := json.Marshal(envelope)
+		if marshalErr != nil {
+			return tmpDir, filePaths, fmt.Errorf("marshalling envelope %d: %w", i, marshalErr)
+		}
+		if writeErr := os.WriteFile(path, body, 0o600); writeErr != nil {
+			return tmpDir, filePaths, fmt.Errorf("writing %s: %w", path, writeErr)
+		}
+		filePaths = append(filePaths, path)
+	}
+	return tmpDir, filePaths, nil
+}

--- a/internal/workflows/test/scan_result_test.go
+++ b/internal/workflows/test/scan_result_test.go
@@ -1,0 +1,93 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Each ScanResultInput is written to scan_results/scan_result_<n>.json wrapped
+// in the {schema, scanResult} envelope, with schema carrying the plugin
+// version as a suffix (e.g. "snyk.container.scan_result.6.5.0").
+func TestWriteScanResultsTempDir_ProducesEnvelopes(t *testing.T) {
+	inputs := []ScanResultInput{
+		{ScanResult: json.RawMessage(`{"identity":{"type":"apk"}}`), PluginVersion: "6.5.0"},
+		{ScanResult: json.RawMessage(`{"identity":{"type":"npm"}}`), PluginVersion: "6.5.0"},
+	}
+
+	tmpDir, paths, err := writeScanResultsTempDir(inputs)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+
+	for i, path := range paths {
+		expected := filepath.Join(tmpDir, "scan_results", fmt.Sprintf("scan_result_%d.json", i))
+		assert.Equal(t, expected, path, "file path should follow scan_results/scan_result_<n>.json")
+
+		body, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+
+		var env struct {
+			Schema     string          `json:"schema"`
+			ScanResult json.RawMessage `json:"scanResult"`
+		}
+		require.NoError(t, json.Unmarshal(body, &env))
+		assert.Equal(t, "snyk.container.scan_result.6.5.0", env.Schema)
+		assert.JSONEq(t, string(inputs[i].ScanResult), string(env.ScanResult))
+		assert.NotContains(t, string(body), "pluginVersion",
+			"pluginVersion is no longer a top-level envelope field; it rides on the schema suffix")
+	}
+}
+
+// When the input carries no plugin version, the schema still ends with the
+// prefix (trailing dot); the engine tolerates an empty suffix.
+func TestWriteScanResultsTempDir_EmptyPluginVersion(t *testing.T) {
+	inputs := []ScanResultInput{
+		{ScanResult: json.RawMessage(`{"identity":{"type":"apk"}}`)},
+	}
+
+	tmpDir, paths, err := writeScanResultsTempDir(inputs)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+
+	body, err := os.ReadFile(paths[0])
+	require.NoError(t, err)
+
+	var env struct {
+		Schema string `json:"schema"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	assert.Equal(t, "snyk.container.scan_result.", env.Schema)
+}
+
+// Empty input still produces a usable temp dir with the scan_results subdirectory.
+func TestWriteScanResultsTempDir_EmptyInput(t *testing.T) {
+	tmpDir, paths, err := writeScanResultsTempDir(nil)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+
+	info, statErr := os.Stat(filepath.Join(tmpDir, "scan_results"))
+	require.NoError(t, statErr)
+	assert.True(t, info.IsDir())
+}


### PR DESCRIPTION
## What this does

First layer of the container-cli Dragonfly stack ([Epic CN-1470](https://snyksec.atlassian.net/browse/CN-1470)). Adds two pure-stdlib primitives that later layers depend on. No new module dependencies; all produced code is dead at runtime until sub-ticket F's workflow registration lands.

**1. Envelope writer** (`scan_result.go`)
Writes each `ScanResult` JSON payload to `<tmpDir>/scan_results/scan_result_<n>.json` wrapped in the v1 envelope:
```json
{ "schema": "snyk.container.scan_result.v1", "scanResult": { ... }, "pluginVersion": "6.5.0" }
```
`pluginVersion` is `omitempty` — empty string is acceptable for emitter cohorts that predate the field. The caller (sub-ticket D's legacy-invoke parser) will extract `PluginVersion` from each `scanResult.facts[]` and pass it in.

**2. Error vocabulary** (`errors.go`)
Three structured error types for later layers' fail-closed paths:
- `SkippedFilesError` — File Upload API silently dropped one or more files
- `ComponentFailureError` — one or more per-component tests errored on the platform side
- `IncompleteFindingsError` — FindingData pagination did not drain to `complete=true`

## Why the new envelope shape

The contract was updated during container-engine work (see PR #19 in container-engine) from `{schema, data}` → `{schema, scanResult, pluginVersion}`. This PR produces the new shape so container-engine decodes it cleanly.

## Tests

- `scan_result_test.go` — envelope JSON shape, file path layout, `omitempty` on `pluginVersion`, empty-input edge case
- `errors_test.go` — message contents and `errors.As` unwrapping for all three types

`go test -race -count=1 ./internal/workflows/test/...` → pass
`golangci-lint run ./internal/workflows/test/...` → 0 issues

## Stack context

Sub-ticket [CN-1471](https://snyksec.atlassian.net/browse/CN-1471). First of ~10 PRs across 6 sub-tickets under epic [CN-1470](https://snyksec.atlassian.net/browse/CN-1470), replacing the single PR #45 with stacked layers.

[CN-1471]: https://snyksec.atlassian.net/browse/CN-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ