### PR TITLE
feat(cn-1473): severity filter, binary separation, regroup, finding conversion

### DIFF
--- a/internal/workflows/test/transform.go
+++ b/internal/workflows/test/transform.go
@@ -29,8 +29,194 @@
 package test
 
 import (
+	"encoding/json"
+	"strings"
+
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 )
+
+// severityOrder ranks severity strings so threshold filtering reduces to a numeric compare.
+// Unknown severities rank 0, which means a finding with an unrecognised severity is dropped
+// the moment any threshold is set — fail-closed by design.
+var severityOrder = map[string]int{
+	"critical": 4,
+	"high":     3,
+	"medium":   2,
+	"low":      1,
+}
+
+// filterBySeverity drops findings below the threshold. An empty or unrecognised threshold
+// keeps everything (matches legacy "no flag, no filter" behaviour).
+func filterBySeverity(findings []testapi.FindingData, threshold string) []testapi.FindingData {
+	if threshold == "" {
+		return findings
+	}
+	minRank := severityOrder[strings.ToLower(threshold)]
+	if minRank == 0 {
+		return findings
+	}
+	out := make([]testapi.FindingData, 0, len(findings))
+	for _, f := range findings {
+		sev := ""
+		if f.Attributes != nil {
+			sev = strings.ToLower(string(f.Attributes.Rating.Severity))
+		}
+		if severityOrder[sev] >= minRank {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// separateBinaryFindings splits findings into package vulns and binary vulns.
+// Binary vulns carry binary-attribution evidence and surface in docker.binariesVulns
+// instead of vulnerabilities[].
+func separateBinaryFindings(findings []testapi.FindingData) (pkg []testapi.FindingData, binary []testapi.FindingData) {
+	for _, f := range findings {
+		if hasBinaryEvidence(f) {
+			binary = append(binary, f)
+		} else {
+			pkg = append(pkg, f)
+		}
+	}
+	return pkg, binary
+}
+
+// hasBinaryEvidence returns true when any Evidence on the finding carries the
+// binary_attribution discriminator. The GAF testapi Evidence union evolves over
+// time; we cope with two surfaces here: the typed Discriminator() helper, and a
+// raw "type" field fallback for forward-compatibility with serialised payloads
+// that the typed union does not yet know about.
+func hasBinaryEvidence(f testapi.FindingData) bool {
+	if f.Attributes == nil {
+		return false
+	}
+	for _, e := range f.Attributes.Evidence {
+		if disc, err := e.Discriminator(); err == nil && disc == "binary_attribution" {
+			return true
+		}
+		bts, err := e.MarshalJSON()
+		if err != nil {
+			continue
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(bts, &raw); err != nil {
+			continue
+		}
+		typeVal, ok := raw["type"]
+		if !ok {
+			continue
+		}
+		var typeStr string
+		if err := json.Unmarshal(typeVal, &typeStr); err == nil && typeStr == "binary_attribution" {
+			return true
+		}
+	}
+	return false
+}
+
+// regroupBySourceLocation separates OS findings (no SourceLocation file_path)
+// from app findings and buckets the latter by file_path so the transformer can
+// reconstruct the applications[] array later.
+func regroupBySourceLocation(findings []testapi.FindingData) (
+	osFindings []testapi.FindingData,
+	appFindings map[string][]testapi.FindingData,
+) {
+	appFindings = make(map[string][]testapi.FindingData)
+	for _, f := range findings {
+		tf := sourceLocationFilePath(f)
+		if tf == "" {
+			osFindings = append(osFindings, f)
+		} else {
+			appFindings[tf] = append(appFindings[tf], f)
+		}
+	}
+	return osFindings, appFindings
+}
+
+// sourceLocationFilePath extracts file_path from the first SourceLocation
+// (discriminator="source") on a FindingData. OS findings have no SourceLocation
+// and return "".
+func sourceLocationFilePath(f testapi.FindingData) string {
+	if f.Attributes == nil {
+		return ""
+	}
+	for _, loc := range f.Attributes.Locations {
+		disc, err := loc.Discriminator()
+		if err != nil || disc != "source" {
+			continue
+		}
+		sl, err := loc.AsSourceLocation()
+		if err == nil && sl.FilePath != "" {
+			return sl.FilePath
+		}
+	}
+	return ""
+}
+
+// convertFindings maps a slice of canonical FindingData to the legacy
+// ContainerVuln shape, decorating each vuln with the local dockerfileAnalysis
+// fact (CLI-side; Registry never returned dockerfileInstruction) and the
+// test-level BaseImageRemediationFact (dockerBaseImage).
+func convertFindings(
+	findings []testapi.FindingData,
+	metas []ScanResultMeta,
+	metaIdx int,
+	baseImageFact *BaseImageRemediationFact,
+) []ContainerVuln {
+	var meta *ScanResultMeta
+	if metaIdx >= 0 && metaIdx < len(metas) {
+		meta = &metas[metaIdx]
+	}
+
+	vulns := make([]ContainerVuln, 0, len(findings))
+	for _, f := range findings {
+		v := findingToVuln(f)
+		if meta != nil && len(meta.DockerfilePackages) > 0 {
+			pkgBase := strings.SplitN(v.PackageName, "/", 2)[0]
+			if cmd, ok := meta.DockerfilePackages[pkgBase]; ok {
+				v.DockerfileInstruction = cmd
+			}
+		}
+		if baseImageFact != nil && baseImageFact.BaseImageName != "" {
+			v.DockerBaseImage = baseImageFact.BaseImageName
+		}
+		vulns = append(vulns, v)
+	}
+	return vulns
+}
+
+// findingToVuln maps a single canonical FindingData to ContainerVuln. Pulls
+// package name+version from the first PackageLocation; falls back to id-as-name
+// when no PackageLocation is present.
+func findingToVuln(f testapi.FindingData) ContainerVuln {
+	v := ContainerVuln{}
+	if f.Id != nil {
+		v.ID = f.Id.String()
+		v.Name = v.ID
+	}
+	if f.Attributes == nil {
+		return v
+	}
+
+	v.Title = f.Attributes.Title
+	v.Severity = strings.ToLower(string(f.Attributes.Rating.Severity))
+
+	for _, loc := range f.Attributes.Locations {
+		disc, err := loc.Discriminator()
+		if err != nil || disc != "package" {
+			continue
+		}
+		pl, err := loc.AsPackageLocation()
+		if err == nil {
+			v.PackageName = pl.Package.Name
+			v.Name = pl.Package.Name
+			v.Version = pl.Package.Version
+			break
+		}
+	}
+	return v
+}
 
 // ContainerTestResult is the top-level JSON shape for snyk container test --json output.
 // It mirrors the legacy TypeScript LegacyVulnerabilityResponse for docker/container.

--- a/internal/workflows/test/transform_test.go
+++ b/internal/workflows/test/transform_test.go
@@ -1,0 +1,190 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- helpers --------------------------------------------------------------
+
+func makeUUID(t *testing.T, s string) openapi_types.UUID {
+	t.Helper()
+	var id openapi_types.UUID
+	require.NoError(t, id.UnmarshalText([]byte(s)))
+	return id
+}
+
+func makePackageLocation(t *testing.T, name, version string) testapi.FindingLocation {
+	t.Helper()
+	pl := testapi.PackageLocation{
+		Package: testapi.Package{Name: name, Version: version},
+		Type:    "package",
+	}
+	var loc testapi.FindingLocation
+	require.NoError(t, loc.FromPackageLocation(pl))
+	return loc
+}
+
+func makeSourceLocation(t *testing.T, filePath string) testapi.FindingLocation {
+	t.Helper()
+	sl := testapi.SourceLocation{
+		FilePath: filePath,
+		Type:     "source",
+	}
+	var loc testapi.FindingLocation
+	require.NoError(t, loc.FromSourceLocation(sl))
+	return loc
+}
+
+func makeBinaryEvidence(t *testing.T) testapi.Evidence {
+	t.Helper()
+	var e testapi.Evidence
+	require.NoError(t, json.Unmarshal([]byte(`{"type":"binary_attribution"}`), &e))
+	return e
+}
+
+func makeFinding(t *testing.T, id, title, severity string, locs ...testapi.FindingLocation) testapi.FindingData {
+	t.Helper()
+	uid := makeUUID(t, id)
+	return testapi.FindingData{
+		Id: &uid,
+		Attributes: &testapi.FindingAttributes{
+			Title:     title,
+			Rating:    testapi.Rating{Severity: testapi.Severity(severity)},
+			Locations: locs,
+		},
+	}
+}
+
+// --- filterBySeverity -----------------------------------------------------
+
+// Empty threshold returns input unchanged.
+func TestFilterBySeverity_EmptyThresholdIsPassThrough(t *testing.T) {
+	in := []testapi.FindingData{
+		makeFinding(t, "11111111-1111-1111-1111-111111111111", "t1", "low"),
+	}
+	assert.Equal(t, in, filterBySeverity(in, ""))
+}
+
+// Threshold drops findings below the rank and keeps findings at or above.
+func TestFilterBySeverity_DropsBelowThresholdKeepsAtOrAbove(t *testing.T) {
+	findings := []testapi.FindingData{
+		makeFinding(t, "11111111-1111-1111-1111-111111111111", "low", "low"),
+		makeFinding(t, "22222222-2222-2222-2222-222222222222", "medium", "medium"),
+		makeFinding(t, "33333333-3333-3333-3333-333333333333", "high", "high"),
+		makeFinding(t, "44444444-4444-4444-4444-444444444444", "critical", "critical"),
+	}
+	got := filterBySeverity(findings, "high")
+	require.Len(t, got, 2)
+	assert.Equal(t, "high", got[0].Attributes.Title)
+	assert.Equal(t, "critical", got[1].Attributes.Title)
+}
+
+// --- separateBinaryFindings -----------------------------------------------
+
+// A finding with binary_attribution evidence ends up in the binary slice; others stay in pkg.
+func TestSeparateBinaryFindings_RoutesBinaryAttribution(t *testing.T) {
+	pkgFinding := makeFinding(t, "11111111-1111-1111-1111-111111111111", "pkg", "high")
+	binaryFinding := makeFinding(t, "22222222-2222-2222-2222-222222222222", "binary", "high")
+	binaryFinding.Attributes.Evidence = []testapi.Evidence{makeBinaryEvidence(t)}
+
+	pkg, binary := separateBinaryFindings([]testapi.FindingData{pkgFinding, binaryFinding})
+	require.Len(t, pkg, 1)
+	require.Len(t, binary, 1)
+	assert.Equal(t, "pkg", pkg[0].Attributes.Title)
+	assert.Equal(t, "binary", binary[0].Attributes.Title)
+}
+
+// --- regroupBySourceLocation ----------------------------------------------
+
+// Findings without SourceLocation go to OS; findings with one bucket by file_path.
+func TestRegroupBySourceLocation_SplitsOSAndApp(t *testing.T) {
+	findings := []testapi.FindingData{
+		makeFinding(t, "11111111-1111-1111-1111-111111111111", "os-1", "high"),
+		makeFinding(t, "22222222-2222-2222-2222-222222222222", "app-1", "high", makeSourceLocation(t, "/app/package.json")),
+		makeFinding(t, "33333333-3333-3333-3333-333333333333", "app-2", "high", makeSourceLocation(t, "/app/package.json")),
+		makeFinding(t, "44444444-4444-4444-4444-444444444444", "app-3", "high", makeSourceLocation(t, "/srv/pom.xml")),
+	}
+	os, apps := regroupBySourceLocation(findings)
+	require.Len(t, os, 1)
+	assert.Equal(t, "os-1", os[0].Attributes.Title)
+	require.Len(t, apps, 2)
+	assert.Len(t, apps["/app/package.json"], 2)
+	assert.Len(t, apps["/srv/pom.xml"], 1)
+}
+
+// --- findingToVuln / convertFindings --------------------------------------
+
+// findingToVuln populates id/title/severity, and pulls package name+version from PackageLocation.
+func TestConvertFindings_PopulatesPackageAndSeverity(t *testing.T) {
+	finding := makeFinding(
+		t,
+		"11111111-1111-1111-1111-111111111111",
+		"some title",
+		"high",
+		makePackageLocation(t, "openssl", "1.1.1d-0"),
+	)
+
+	vulns := convertFindings([]testapi.FindingData{finding}, nil, 0, nil)
+	require.Len(t, vulns, 1)
+	v := vulns[0]
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", v.ID)
+	assert.Equal(t, "some title", v.Title)
+	assert.Equal(t, "high", v.Severity)
+	assert.Equal(t, "openssl", v.PackageName)
+	assert.Equal(t, "openssl", v.Name)
+	assert.Equal(t, "1.1.1d-0", v.Version)
+}
+
+// dockerfileInstruction is decorated from the matching meta's DockerfilePackages map.
+func TestConvertFindings_DecoratesDockerfileInstruction(t *testing.T) {
+	finding := makeFinding(
+		t,
+		"11111111-1111-1111-1111-111111111111",
+		"t",
+		"high",
+		makePackageLocation(t, "openssl", "1.1.1d-0"),
+	)
+	metas := []ScanResultMeta{{
+		DockerfilePackages: map[string]string{"openssl": "RUN apt-get install openssl"},
+	}}
+
+	vulns := convertFindings([]testapi.FindingData{finding}, metas, 0, nil)
+	require.Len(t, vulns, 1)
+	assert.Equal(t, "RUN apt-get install openssl", vulns[0].DockerfileInstruction)
+}
+
+// dockerBaseImage is decorated from the test-level BaseImageRemediationFact when present.
+func TestConvertFindings_DecoratesDockerBaseImage(t *testing.T) {
+	finding := makeFinding(
+		t,
+		"11111111-1111-1111-1111-111111111111",
+		"t",
+		"high",
+		makePackageLocation(t, "openssl", "1.1.1d-0"),
+	)
+	fact := &BaseImageRemediationFact{BaseImageName: "debian:10"}
+
+	vulns := convertFindings([]testapi.FindingData{finding}, nil, 0, fact)
+	require.Len(t, vulns, 1)
+	assert.Equal(t, "debian:10", vulns[0].DockerBaseImage)
+}


### PR DESCRIPTION
## What this does

Second of three PRs under sub-ticket [CN-1473](https://snyksec.atlassian.net/browse/CN-1473). Stacked on [#49](https://github.com/snyk/container-cli/pull/49) (types-only).

Adds the per-finding processing helpers that the transform's main entry point will compose in the next PR. Each function takes canonical `testapi.FindingData` and returns either filtered/regrouped findings or `ContainerVuln` values.

## Functions added

- `filterBySeverity` — drops findings below the threshold; pass-through on empty or unrecognised threshold (matches legacy "no flag, no filter")
- `separateBinaryFindings` / `hasBinaryEvidence` — routes findings with `binary_attribution` evidence into `docker.binariesVulns` instead of `vulnerabilities[]`. Forward-compatible: checks both `Discriminator()` and a raw `"type"` field fallback
- `regroupBySourceLocation` / `sourceLocationFilePath` — splits OS (no SourceLocation) from app findings, then buckets the latter by `file_path` so `applications[]` can be reconstructed
- `convertFindings` / `findingToVuln` — maps a slice of canonical FindingData to legacy `ContainerVuln`, decorating with `dockerfileInstruction` (from local `dockerfileAnalysis` fact) and `dockerBaseImage` (from test-level `BaseImageRemediationFact`)
- `severityOrder` map — numeric ranking for threshold comparison; unknown severities rank 0 (fail-closed)

## Tests

7 cases covering: empty-threshold pass-through, threshold cuts at the right rank, binary-attribution routing, OS vs app split (with multi-bucket grouping by file_path), package metadata extraction from PackageLocation, dockerfileInstruction decoration, dockerBaseImage decoration.

Helpers (`makeUUID`, `makePackageLocation`, `makeSourceLocation`, `makeBinaryEvidence`, `makeFinding`) in the test file build minimal-but-valid `FindingData` shapes via the `testapi`-provided union setters.

`go test -race -count=1 ./internal/workflows/test/...` → pass
`golangci-lint run ./internal/workflows/test/...` → 0 issues

[CN-1473]: https://snyksec.atlassian.net/browse/CN-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ