### PR TITLE
feat(cn-1473): Transform entry, docker section, applications, and base remediation

### DIFF
--- a/internal/workflows/test/transform.go
+++ b/internal/workflows/test/transform.go
@@ -30,10 +30,207 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 )
+
+// Transform converts the flat FindingData stream into the legacy
+// snyk container test --json output shape. Steps:
+//  1. Severity-filter the findings (matches test-outcome-enricher-df ordering).
+//  2. Split binary-attribution findings out of the main stream.
+//  3. Regroup package findings by SourceLocation file_path (OS bucket has none).
+//  4. Map each bucket's findings to ContainerVuln, decorating with dockerfile
+//     and dockerBaseImage as appropriate.
+//  5. Assemble the top-level result with `docker.*`, `applications[]`, and the
+//     OS-level `vulnerabilities[]` + summary text.
+func Transform(input TransformInput) ContainerTestResult {
+	filtered := filterBySeverity(input.Findings, input.SeverityThreshold)
+	packageFindings, binaryFindings := separateBinaryFindings(filtered)
+	osFindings, appBuckets := regroupBySourceLocation(packageFindings)
+
+	osVulns := convertFindings(osFindings, input.ScanResultMetas, 0, input.BaseImageFact)
+	dockerSection := buildDockerSection(input.BaseImageFact, binaryFindings)
+	apps := buildApplications(appBuckets, input.ScanResultMetas)
+
+	return ContainerTestResult{
+		OK:              len(osVulns) == 0 && allAppsOK(apps),
+		Vulnerabilities: osVulns,
+		UniqueCount:     len(osVulns),
+		PackageManager:  osPkgManager(input.ScanResultMetas),
+		Path:            input.ImagePath,
+		Docker:          dockerSection,
+		Applications:    apps,
+		Summary:         buildSummary(len(osVulns)),
+	}
+}
+
+// buildDockerSection assembles the docker: block. Returns nil when there is
+// neither a base-image fact nor any binary findings — the legacy output omits
+// the field entirely in that case.
+func buildDockerSection(fact *BaseImageRemediationFact, binaryFindings []testapi.FindingData) *DockerSection {
+	if fact == nil && len(binaryFindings) == 0 {
+		return nil
+	}
+	d := &DockerSection{}
+	if fact != nil {
+		d.BaseImage = fact.BaseImageName
+		d.BaseImageRemediation = buildBaseImageRemediation(fact)
+	}
+	if len(binaryFindings) > 0 {
+		d.BinariesVulns = buildBinariesVulns(binaryFindings)
+	}
+	return d
+}
+
+// buildBaseImageRemediation reconstructs the legacy advice[] presentation array
+// from the structured BaseImageRemediationFact. Ports the per-code formatters
+// from registry/src/lib/domain/needs-refactoring/docker/cli.ts.
+func buildBaseImageRemediation(fact *BaseImageRemediationFact) *BaseImageRemediation {
+	if fact == nil {
+		return nil
+	}
+	remediation := &BaseImageRemediation{
+		Code:              fact.Code,
+		BaseImageOutdated: fact.BaseImageOutdated,
+	}
+	switch fact.Code {
+	case "REMEDIATION_AVAILABLE":
+		remediation.Advice = formatRemediationAvailable(fact)
+	case "NO_REMEDIATION_AVAILABLE":
+		remediation.Advice = formatNoRemediationAvailable(fact)
+	case "OUTDATED_BASE_IMAGE":
+		remediation.Advice = formatOutdatedBaseImage(fact)
+	case "UNTRACKED_BASE_IMAGE":
+		remediation.Advice = []RemediationLine{
+			{Message: "Base image is not tracked by Snyk. To get base image upgrade recommendations, use an official image."},
+		}
+	case "UNSUPPORTED_REGISTRY":
+		remediation.Advice = []RemediationLine{
+			{Message: "Base image is from an unsupported registry. Snyk currently supports Docker Hub and select registries."},
+		}
+	case "INVALID_BASE_IMAGE_NAME":
+		remediation.Advice = []RemediationLine{
+			{Message: "Could not parse base image name from the Dockerfile."},
+		}
+	}
+	return remediation
+}
+
+func formatRemediationAvailable(fact *BaseImageRemediationFact) []RemediationLine {
+	return []RemediationLine{
+		{Message: fmt.Sprintf("Upgrade your base image from %s to a newer version:", fact.BaseImageName), Bold: true},
+		{Message: fmt.Sprintf("We recommend upgrading to a newer tag of %s to fix the vulnerabilities.", fact.BaseImageName)},
+	}
+}
+
+func formatNoRemediationAvailable(fact *BaseImageRemediationFact) []RemediationLine {
+	return []RemediationLine{
+		{Message: fmt.Sprintf("No upgrade available for base image %s.", fact.BaseImageName), Bold: true},
+		{Message: "Consider using a different base image."},
+	}
+}
+
+func formatOutdatedBaseImage(fact *BaseImageRemediationFact) []RemediationLine {
+	return []RemediationLine{
+		{Message: fmt.Sprintf("Your base image %s is outdated.", fact.BaseImageName), Bold: true},
+		{Message: "Upgrade to a newer tag to get security fixes."},
+	}
+}
+
+// buildBinariesVulns converts binary-attribution findings to the legacy
+// binariesVulns shape: a map keyed by issue id + a map of affected packages.
+func buildBinariesVulns(findings []testapi.FindingData) *BinariesVulns {
+	bv := &BinariesVulns{
+		IssuesData:   make(map[string]ContainerVuln),
+		AffectedPkgs: make(map[string]AffectedPkg),
+	}
+	for _, f := range findings {
+		v := findingToVuln(f)
+		bv.IssuesData[v.ID] = v
+
+		pkgKey := v.PackageName + "@" + v.Version
+		ap, exists := bv.AffectedPkgs[pkgKey]
+		if !exists {
+			ap = AffectedPkg{
+				Pkg:    PkgRef{Name: v.PackageName, Version: v.Version},
+				Issues: make(map[string]IssueRef),
+			}
+		}
+		ap.Issues[v.ID] = IssueRef{IssueID: v.ID}
+		bv.AffectedPkgs[pkgKey] = ap
+	}
+	return bv
+}
+
+// buildApplications builds the applications[] slice from per-targetFile finding
+// buckets, each one paired with the matching ScanResultMeta for packageManager
+// and project name. Buckets without a matching meta still appear, just with
+// empty packageManager/projectName.
+func buildApplications(appBuckets map[string][]testapi.FindingData, metas []ScanResultMeta) []AppResult {
+	if len(appBuckets) == 0 {
+		return nil
+	}
+	apps := make([]AppResult, 0, len(appBuckets))
+	for tf, findings := range appBuckets {
+		metaIdx := findMetaByTargetFile(metas, tf)
+		vulns := convertFindings(findings, metas, metaIdx, nil)
+
+		var pm, name string
+		if metaIdx >= 0 {
+			pm = metas[metaIdx].PackageManager
+			name = metas[metaIdx].Name
+		}
+		apps = append(apps, AppResult{
+			Vulnerabilities:   vulns,
+			PackageManager:    pm,
+			TargetFile:        tf,
+			ProjectName:       name,
+			DisplayTargetFile: tf,
+			UniqueCount:       len(vulns),
+			OK:                len(vulns) == 0,
+			Summary:           buildSummary(len(vulns)),
+		})
+	}
+	return apps
+}
+
+func findMetaByTargetFile(metas []ScanResultMeta, targetFile string) int {
+	for i, m := range metas {
+		if m.TargetFile == targetFile {
+			return i
+		}
+	}
+	return -1
+}
+
+func osPkgManager(metas []ScanResultMeta) string {
+	if len(metas) > 0 {
+		return metas[0].PackageManager
+	}
+	return ""
+}
+
+func allAppsOK(apps []AppResult) bool {
+	for _, a := range apps {
+		if !a.OK {
+			return false
+		}
+	}
+	return true
+}
+
+func buildSummary(vulnCount int) string {
+	switch vulnCount {
+	case 0:
+		return "No known vulnerabilities"
+	case 1:
+		return "1 known vulnerability"
+	default:
+		return fmt.Sprintf("%d known vulnerabilities", vulnCount)
+	}
+}
 
 // severityOrder ranks severity strings so threshold filtering reduces to a numeric compare.
 // Unknown severities rank 0, which means a finding with an unrecognised severity is dropped

--- a/internal/workflows/test/transform_test.go
+++ b/internal/workflows/test/transform_test.go
@@ -173,6 +173,100 @@ func TestConvertFindings_DecoratesDockerfileInstruction(t *testing.T) {
 	assert.Equal(t, "RUN apt-get install openssl", vulns[0].DockerfileInstruction)
 }
 
+// --- Transform end-to-end ------------------------------------------------
+
+// Empty findings produce an OK result with no vulns/apps and the no-vulns summary.
+func TestTransform_EmptyFindings(t *testing.T) {
+	got := Transform(TransformInput{ImagePath: "alpine:3.17"})
+	assert.True(t, got.OK)
+	assert.Empty(t, got.Vulnerabilities)
+	assert.Empty(t, got.Applications)
+	assert.Equal(t, "No known vulnerabilities", got.Summary)
+	assert.Equal(t, "alpine:3.17", got.Path)
+}
+
+// OS findings flow to vulnerabilities[]; app findings flow to applications[];
+// the buckets are matched to metas by file_path for packageManager + projectName.
+func TestTransform_MixedOSAndAppFindings(t *testing.T) {
+	findings := []testapi.FindingData{
+		makeFinding(t, "11111111-1111-1111-1111-111111111111", "os-vuln", "high",
+			makePackageLocation(t, "openssl", "1.1.1d-0"),
+		),
+		makeFinding(t, "22222222-2222-2222-2222-222222222222", "app-vuln", "medium",
+			makeSourceLocation(t, "/app/package.json"),
+			makePackageLocation(t, "lodash", "4.17.0"),
+		),
+	}
+	metas := []ScanResultMeta{
+		{PackageManager: "deb"},
+		{TargetFile: "/app/package.json", PackageManager: "npm", Name: "my-app"},
+	}
+	got := Transform(TransformInput{
+		Findings:        findings,
+		ScanResultMetas: metas,
+		ImagePath:       "node:18",
+	})
+
+	assert.False(t, got.OK)
+	require.Len(t, got.Vulnerabilities, 1)
+	assert.Equal(t, "openssl", got.Vulnerabilities[0].PackageName)
+	assert.Equal(t, "deb", got.PackageManager)
+
+	require.Len(t, got.Applications, 1)
+	app := got.Applications[0]
+	assert.Equal(t, "/app/package.json", app.TargetFile)
+	assert.Equal(t, "npm", app.PackageManager)
+	assert.Equal(t, "my-app", app.ProjectName)
+	require.Len(t, app.Vulnerabilities, 1)
+	assert.Equal(t, "lodash", app.Vulnerabilities[0].PackageName)
+}
+
+// BaseImageRemediationFact builds the docker.baseImageRemediation block with
+// a per-code advice array; the base image string flows onto docker.baseImage.
+func TestTransform_BuildsDockerBaseImageRemediation(t *testing.T) {
+	got := Transform(TransformInput{
+		ImagePath: "debian:10",
+		BaseImageFact: &BaseImageRemediationFact{
+			Code:              "OUTDATED_BASE_IMAGE",
+			BaseImageName:     "debian:10",
+			BaseImageOutdated: true,
+		},
+	})
+
+	require.NotNil(t, got.Docker)
+	assert.Equal(t, "debian:10", got.Docker.BaseImage)
+	require.NotNil(t, got.Docker.BaseImageRemediation)
+	rem := got.Docker.BaseImageRemediation
+	assert.Equal(t, "OUTDATED_BASE_IMAGE", rem.Code)
+	assert.True(t, rem.BaseImageOutdated)
+	require.NotEmpty(t, rem.Advice)
+	assert.Contains(t, rem.Advice[0].Message, "debian:10")
+}
+
+// Binary-attribution findings populate docker.binariesVulns with the issuesData +
+// affectedPkgs shape the legacy CLI consumers expect.
+func TestTransform_BuildsBinariesVulns(t *testing.T) {
+	binary := makeFinding(
+		t,
+		"55555555-5555-5555-5555-555555555555",
+		"binary-vuln",
+		"high",
+		makePackageLocation(t, "node", "18.0.0"),
+	)
+	binary.Attributes.Evidence = []testapi.Evidence{makeBinaryEvidence(t)}
+
+	got := Transform(TransformInput{
+		Findings:  []testapi.FindingData{binary},
+		ImagePath: "node:18",
+	})
+
+	require.NotNil(t, got.Docker)
+	require.NotNil(t, got.Docker.BinariesVulns)
+	assert.Len(t, got.Docker.BinariesVulns.IssuesData, 1)
+	assert.Len(t, got.Docker.BinariesVulns.AffectedPkgs, 1)
+	assert.Empty(t, got.Vulnerabilities, "binary findings must not appear in OS vulnerabilities[]")
+}
+
 // dockerBaseImage is decorated from the test-level BaseImageRemediationFact when present.
 func TestConvertFindings_DecoratesDockerBaseImage(t *testing.T) {
 	finding := makeFinding(


### PR DESCRIPTION
## What this does

Third and final PR under sub-ticket [CN-1473](https://snyksec.atlassian.net/browse/CN-1473) (FindingData → legacy transform). Stacked on [#50](https://github.com/snyk/container-cli/pull/50). With this PR, `Transform()` becomes a callable end-to-end transformer; previous PRs in this sub-stack only added supporting types and helpers.

## Functions added

- `Transform(input)` — top-level entry point: filter → split binary → regroup → convert → assemble docker section + applications → assemble top-level result with `summary`, `ok`, `path`
- `buildDockerSection` — assembles `docker.*`; returns nil when neither base-image fact nor binary findings present (matches legacy "omit field entirely")
- `buildBaseImageRemediation` + `formatRemediationAvailable` / `formatNoRemediationAvailable` / `formatOutdatedBaseImage` — reconstructs the legacy advice[] presentation array from the structured `BaseImageRemediationFact` (ports per-code formatters from registry/cli.ts)
- `buildBinariesVulns` — converts binary-attribution findings into the legacy `binariesVulns` shape (issuesData map + affectedPkgs map keyed by name@version)
- `buildApplications` — builds `applications[]` from per-targetFile finding buckets, matching to `ScanResultMeta` for packageManager + projectName
- `findMetaByTargetFile`, `osPkgManager`, `allAppsOK`, `buildSummary` — small helpers

## Tests

4 new end-to-end tests on top of the 7 helper tests from #50:

- Empty findings → OK result, no-vulns summary, image path preserved
- Mixed OS + app findings → OS vulns in `vulnerabilities[]`, app vulns in `applications[]`, packageManager from matched meta, ProjectName from meta
- `BaseImageRemediationFact` → docker.baseImage + docker.baseImageRemediation with per-code advice array
- Binary-attribution findings → docker.binariesVulns populated, OS vulnerabilities[] stays empty

`go test -race -count=1 ./internal/workflows/test/...` → pass (11 tests in transform_test.go now)
`golangci-lint run ./internal/workflows/test/...` → 0 issues

## Sub-ticket C now complete

Sub-ticket [CN-1473](https://snyksec.atlassian.net/browse/CN-1473) is done across PRs #49 (types), #50 (filter/regroup/convert), and this PR. The `Transform()` function is callable; sub-ticket E's flow orchestrator will invoke it once the findings have been drained.

[CN-1473]: https://snyksec.atlassian.net/browse/CN-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-1473]: https://snyksec.atlassian.net/browse/CN-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ