### PR TITLE
feat(cn-1474): add legacy CLI scan-result acquisition with pluginVersion fact extraction

### DIFF
--- a/internal/workflows/test/legacy_invoke.go
+++ b/internal/workflows/test/legacy_invoke.go
@@ -1,0 +1,186 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/container-cli/internal/common/constants"
+	"github.com/snyk/container-cli/internal/common/flags"
+)
+
+// pluginResponse mirrors snyk-docker-plugin's PluginResponse type. Only the
+// fields we read are declared; the rest of the response is irrelevant on the
+// container-cli side because the engine treats scanResult bytes as opaque.
+type pluginResponse struct {
+	ScanResults []rawScanResult `json:"scanResults"`
+}
+
+// rawScanResult is the JSON shape of one ScanResult from snyk-docker-plugin.
+// Most fields are stored as raw bytes so the writer can forward the original
+// JSON byte-identical to container-engine without re-serialising.
+type rawScanResult struct {
+	Name            string             `json:"name,omitempty"`
+	Policy          string             `json:"policy,omitempty"`
+	Target          json.RawMessage    `json:"target"`
+	Identity        scanResultIdentity `json:"identity"`
+	Facts           []scanResultFact   `json:"facts"`
+	TargetReference string             `json:"targetReference,omitempty"`
+}
+
+type scanResultIdentity struct {
+	Type       string `json:"type"`
+	TargetFile string `json:"targetFile,omitempty"`
+}
+
+// scanResultFact is one entry in scanResult.facts[]. Data is kept as raw bytes
+// so callers can unmarshal into the type-specific shape they need.
+type scanResultFact struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// dockerfileAnalysisData is the shape of the dockerfileAnalysis fact's data
+// payload, used to decorate ContainerVuln.DockerfileInstruction client-side.
+type dockerfileAnalysisData struct {
+	DockerfilePackages map[string]struct {
+		InstallCommand string `json:"installCommand"`
+	} `json:"dockerfilePackages"`
+}
+
+// pluginVersionFactType is the type discriminator snyk-docker-plugin uses for
+// its version fact. See snyk-docker-plugin/lib/facts.ts type "pluginVersion".
+const pluginVersionFactType = "pluginVersion"
+
+// dockerfileAnalysisFactType is the type discriminator for the local dockerfile
+// analysis fact, which carries package → install command mappings.
+const dockerfileAnalysisFactType = "dockerfileAnalysis"
+
+// acquireScanResults invokes the legacy TypeScript CLI to run snyk-docker-plugin
+// and captures the ScanResult[] output, returning per-ScanResult inputs ready
+// for the envelope writer plus per-ScanResult metadata for the transformer.
+//
+// Phase 1 strategy: shell out via legacycli with `--print-graph --json` (same
+// pattern the depgraph workflow uses) and parse the full plugin output JSON.
+// Rewriting the TypeScript scanner in Go is a separate workstream.
+//
+//nolint:unused // Consumed by the flow orchestrator in a follow-on PR (sub-ticket E).
+func acquireScanResults(ictx workflow.InvocationContext) ([]ScanResultInput, []ScanResultMeta, error) {
+	cfg := ictx.GetConfiguration()
+	logger := ictx.GetEnhancedLogger()
+
+	cmdArgs := []string{"container", "test", "--print-graph", "--json"}
+	for _, flag := range flags.CommonFlags {
+		if arg := flag.GetAsCLIArgument(cfg); arg != "" {
+			cmdArgs = append(cmdArgs, arg)
+		}
+	}
+	cmdArgs = append(cmdArgs, cfg.GetString(constants.ContainerTargetArgName))
+
+	logger.Info().Msgf("container test: invoking legacy CLI: %v", cmdArgs)
+
+	legacyCfg := cfg.Clone()
+	legacyCfg.Set(configuration.RAW_CMD_ARGS, cmdArgs)
+	data, err := ictx.GetEngine().InvokeWithConfig(
+		workflow.NewWorkflowIdentifier(constants.WorkflowIdentifierLegacyCli),
+		legacyCfg,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("legacy CLI invocation failed: %w", err)
+	}
+	if len(data) == 0 || data[0] == nil {
+		return nil, nil, fmt.Errorf("legacy CLI returned empty response")
+	}
+	payload, ok := data[0].GetPayload().([]byte)
+	if !ok {
+		return nil, nil, fmt.Errorf("unexpected legacy CLI payload type: %T", data[0].GetPayload())
+	}
+
+	return parseScanResults(payload)
+}
+
+// parseScanResults unmarshals the legacy CLI's JSON output into the typed
+// inputs the rest of the workflow needs. Exposed as a standalone function so
+// tests can drive it directly without standing up a workflow engine.
+func parseScanResults(payload []byte) ([]ScanResultInput, []ScanResultMeta, error) {
+	var resp pluginResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return nil, nil, fmt.Errorf("parsing plugin response: %w", err)
+	}
+	if len(resp.ScanResults) == 0 {
+		return nil, nil, fmt.Errorf("plugin response has no scanResults")
+	}
+
+	inputs := make([]ScanResultInput, 0, len(resp.ScanResults))
+	metas := make([]ScanResultMeta, 0, len(resp.ScanResults))
+	for _, sr := range resp.ScanResults {
+		raw, err := json.Marshal(sr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("re-encoding scan result: %w", err)
+		}
+		inputs = append(inputs, ScanResultInput{
+			ScanResult:    raw,
+			PluginVersion: extractPluginVersion(sr),
+		})
+		metas = append(metas, buildScanResultMeta(sr))
+	}
+	return inputs, metas, nil
+}
+
+// extractPluginVersion returns the snyk-docker-plugin version recorded inside
+// scanResult.facts[type="pluginVersion"]. Returns empty string when the fact
+// is absent — the envelope writer treats empty as "emitter cohort predates
+// the field" and omits the JSON field.
+func extractPluginVersion(sr rawScanResult) string {
+	for _, fact := range sr.Facts {
+		if fact.Type != pluginVersionFactType {
+			continue
+		}
+		var version string
+		if err := json.Unmarshal(fact.Data, &version); err == nil {
+			return version
+		}
+	}
+	return ""
+}
+
+// buildScanResultMeta extracts per-ScanResult metadata the transformer needs
+// for regrouping and dockerfileInstruction decoration.
+func buildScanResultMeta(sr rawScanResult) ScanResultMeta {
+	meta := ScanResultMeta{
+		TargetFile:     sr.Identity.TargetFile,
+		PackageManager: sr.Identity.Type,
+		Name:           sr.Name,
+	}
+	for _, fact := range sr.Facts {
+		if fact.Type != dockerfileAnalysisFactType {
+			continue
+		}
+		var dfa dockerfileAnalysisData
+		if err := json.Unmarshal(fact.Data, &dfa); err != nil {
+			break
+		}
+		meta.DockerfilePackages = make(map[string]string, len(dfa.DockerfilePackages))
+		for pkg, v := range dfa.DockerfilePackages {
+			meta.DockerfilePackages[pkg] = v.InstallCommand
+		}
+		break
+	}
+	return meta
+}

--- a/internal/workflows/test/legacy_invoke_test.go
+++ b/internal/workflows/test/legacy_invoke_test.go
@@ -1,0 +1,108 @@
+// © 2023-2026 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const pluginResponseFixture = `{
+  "scanResults": [
+    {
+      "name": "alpine:3.17",
+      "target": {"image": "alpine:3.17"},
+      "identity": {"type": "apk"},
+      "facts": [
+        {"type": "pluginVersion", "data": "6.5.0"},
+        {
+          "type": "dockerfileAnalysis",
+          "data": {"dockerfilePackages": {"openssl": {"installCommand": "RUN apk add openssl"}}}
+        }
+      ]
+    },
+    {
+      "name": "alpine:3.17/usr/src/app",
+      "target": {"image": "alpine:3.17"},
+      "identity": {"type": "npm", "targetFile": "/usr/src/app/package.json"},
+      "facts": [
+        {"type": "pluginVersion", "data": "6.5.0"}
+      ]
+    }
+  ]
+}`
+
+// One ScanResultInput per scanResult; the inner ScanResult bytes round-trip back
+// to the original JSON (so container-engine sees them byte-identical to the plugin output).
+func TestParseScanResults_ProducesOneInputPerScanResult(t *testing.T) {
+	inputs, metas, err := parseScanResults([]byte(pluginResponseFixture))
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+	require.Len(t, metas, 2)
+
+	var first rawScanResult
+	require.NoError(t, json.Unmarshal(inputs[0].ScanResult, &first))
+	assert.Equal(t, "alpine:3.17", first.Name)
+	assert.Equal(t, "apk", first.Identity.Type)
+}
+
+// The pluginVersion fact lands on each ScanResultInput so the envelope writer can stamp it.
+func TestParseScanResults_ExtractsPluginVersionFromFacts(t *testing.T) {
+	inputs, _, err := parseScanResults([]byte(pluginResponseFixture))
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+	for i, input := range inputs {
+		assert.Equal(t, "6.5.0", input.PluginVersion, "input %d", i)
+	}
+}
+
+// When no pluginVersion fact is present, the extracted version is empty
+// (envelope writer's omitempty drops the field from the wire JSON).
+func TestExtractPluginVersion_AbsentFactReturnsEmpty(t *testing.T) {
+	sr := rawScanResult{Facts: []scanResultFact{
+		{Type: "dockerfileAnalysis", Data: json.RawMessage(`{}`)},
+	}}
+	assert.Empty(t, extractPluginVersion(sr))
+}
+
+// Metadata extraction: identity.type and identity.targetFile flow through, and
+// the dockerfileAnalysis fact populates DockerfilePackages.
+func TestBuildScanResultMeta_PopulatesIdentityAndDockerfilePackages(t *testing.T) {
+	inputs, metas, err := parseScanResults([]byte(pluginResponseFixture))
+	require.NoError(t, err)
+	require.Len(t, metas, 2)
+	require.Len(t, inputs, 2)
+
+	osMeta := metas[0]
+	assert.Equal(t, "", osMeta.TargetFile, "OS scan result has no target file")
+	assert.Equal(t, "apk", osMeta.PackageManager)
+	assert.Equal(t, "RUN apk add openssl", osMeta.DockerfilePackages["openssl"])
+
+	appMeta := metas[1]
+	assert.Equal(t, "/usr/src/app/package.json", appMeta.TargetFile)
+	assert.Equal(t, "npm", appMeta.PackageManager)
+	assert.Empty(t, appMeta.DockerfilePackages, "no dockerfile fact on this scan result")
+}
+
+// An empty or malformed plugin response is rejected with a clear error rather
+// than silently producing zero ScanResultInputs (which would lead to an empty upload).
+func TestParseScanResults_RejectsEmptyResponse(t *testing.T) {
+	_, _, err := parseScanResults([]byte(`{"scanResults":[]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no scanResults")
+}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

_Explain why this PR exists_

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_
